### PR TITLE
alt-is-optional

### DIFF
--- a/src/components/Image/Image.jsx
+++ b/src/components/Image/Image.jsx
@@ -12,7 +12,7 @@ const Image = ({ alt, height, src, width, ...props }) => (
 )
 
 Image.propTypes = {
-  alt: PropTypes.string.isRequired,
+  alt: PropTypes.string,
   height: PropTypes.oneOfType([
     PropTypes.string, // allows percentages
     PropTypes.number, // uses pixels

--- a/src/compounds/Header/Header.jsx
+++ b/src/compounds/Header/Header.jsx
@@ -31,7 +31,7 @@ Header.propTypes = {
   browseLink: PropTypes.string.isRequired,
   logo: PropTypes.shape({
     src: PropTypes.string.isRequired,
-    alt: PropTypes.string.isRequired,
+    alt: PropTypes.string,
   }).isRequired,
   logInLink: PropTypes.string.isRequired,
   logOutLink: PropTypes.string.isRequired,

--- a/src/compounds/Item/Item.jsx
+++ b/src/compounds/Item/Item.jsx
@@ -79,7 +79,7 @@ Item.propTypes = {
     id: PropTypes.number.isRequired,
     img: PropTypes.shape({
       src: PropTypes.string.isRequired,
-      alt: PropTypes.string.isRequired,
+      alt: PropTypes.string,
     }).isRequired,
     name: PropTypes.string.isRequired,
     slug: PropTypes.string,

--- a/src/compounds/Logo/Logo.jsx
+++ b/src/compounds/Logo/Logo.jsx
@@ -9,7 +9,7 @@ const Logo = ({ alt, src }) => (
 )
 
 Logo.propTypes = {
-  alt: PropTypes.string.isRequired,
+  alt: PropTypes.string,
   src: PropTypes.string.isRequired,
 }
 


### PR DESCRIPTION
# story
the alt tag on images has been deemed as a non mvp request since the api is currently not capable of this. you can read the discussion [here](https://github.com/assaydepot/scientist_api_v2/issues/185).

# expected behavior
- make the alt property on an image optional