### PR TITLE
home story import

### DIFF
--- a/src/pages/Home.stories.jsx
+++ b/src/pages/Home.stories.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { LoggedOut } from '../compounds/Header/Header.stories'
 import { Alternate as Footer } from '../compounds/Footer/Footer.stories'
 import { Alternate as Hero } from '../components/Image/Image.stories'
-import { Alternate as ItemGroup } from '../compounds/ItemGroup/ItemGroup.stories'
+import { withTitleLink as ItemGroup } from '../compounds/ItemGroup/ItemGroup.stories'
 import { Default as SearchBar } from '../components/SearchBar/SearchBar.stories'
 import { Default as TitledTextBox } from '../compounds/TitledTextBox/TitledTextBox.stories'
 


### PR DESCRIPTION
# issue
<img width="1054" alt="image" src="https://user-images.githubusercontent.com/29032869/202020883-af104f6f-4fb6-4cfa-be89-a91e5bc40216.png">

# expected behavior
- there is no longer an [ItemGroup example](https://github.com/scientist-softserv/webstore-component-library/blob/main/src/compounds/ItemGroup/ItemGroup.stories.jsx) titled "Alternate" so I fixed the import for the Home story per the console warning