### PR TITLE
item page styling

### DIFF
--- a/src/components/Loading/Loading.jsx
+++ b/src/components/Loading/Loading.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { TailSpin } from 'react-loader-spinner'
 
-const Loading = ({ color, height, radius, width, ...props }) => (
+const Loading = ({ color, height, radius, width, wrapperStyle, ...props }) => (
   <TailSpin
     ariaLabel='tail-spin-loading'
     color={color}
@@ -10,6 +10,7 @@ const Loading = ({ color, height, radius, width, ...props }) => (
     width={width}
     radius={radius}
     visible={true}
+    wrapperStyle={{ justifyContent: 'center', ...wrapperStyle }}
     {...props}
   />
 )

--- a/src/compounds/ItemPage/ItemPage.jsx
+++ b/src/compounds/ItemPage/ItemPage.jsx
@@ -10,7 +10,7 @@ const ItemPage = ({ title, titleStyle, description, descriptionStyle, img }) => 
   img = { width: 400, ...img }
 
   return (
-    <main className='center-content'>
+    <main className='center-content item-page'>
       <Title title={title} style={titleStyle} />
       <div className='item-page-details'>
         <TextBox text={description} style={descriptionStyle} size='medium' />

--- a/src/compounds/ItemPage/item-page.css
+++ b/src/compounds/ItemPage/item-page.css
@@ -1,3 +1,8 @@
+.item-page {
+  padding-top: 40px;
+  padding-bottom: 40px;
+}
+
 .item-page-details {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
# expected behavior
- add padding to the top and bottom of the item page

# demo
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/29032869/202030724-3b798caf-ec6b-4038-97a2-82c590ce9778.png">
