### PR TITLE
35 request item v2

### DIFF
--- a/src/compounds/RequestItem/RequestItem.jsx
+++ b/src/compounds/RequestItem/RequestItem.jsx
@@ -6,7 +6,15 @@ import TextBox from '../../components/TextBox/TextBox'
 import Title from '../../components/Title/Title'
 import './request-item.css'
 
-const RequestItem = ({ createdAt, description, img, title, status, updatedAt }) => {
+const RequestItem = React.forwardRef(({ createdAt, description, href, img, isLoading, title, status, updatedAt }, ref) => {
+  if (isLoading) {
+    return (
+      <div className='center-content'>
+        <ItemLoading orientation='vertical' />
+      </div>
+    )
+  }
+
   const { backgroundColor, text, textColor } = status
   const image = { ...img, height: 70, width: 70 }
 
@@ -14,7 +22,9 @@ const RequestItem = ({ createdAt, description, img, title, status, updatedAt }) 
     <article className='request-item margin-top'>
       <Image {...image} />
       <div className='request-item-details'>
-        <Title title={title} size='small' />
+        <a href={href} ref={ref} className='link pointer-cursor'>
+          <Title title={title} size='small' />
+        </a>
         <TextBox text={description} />
       </div>
       <div className='status'>
@@ -28,7 +38,7 @@ const RequestItem = ({ createdAt, description, img, title, status, updatedAt }) 
       </div>
     </article>
   )
-}
+})
 
 RequestItem.propTypes = {
   createdAt: PropTypes.string.isRequired,
@@ -37,6 +47,10 @@ RequestItem.propTypes = {
   status: PropTypes.shape(Badge.propTypes).isRequired,
   title: PropTypes.string.isRequired,
   updatedAt: PropTypes.string.isRequired,
+}
+
+RequestItem.defaultProps = {
+  isLoading: false,
 }
 
 export default RequestItem

--- a/src/compounds/RequestItem/RequestItem.jsx
+++ b/src/compounds/RequestItem/RequestItem.jsx
@@ -11,9 +11,9 @@ const RequestItem = ({ createdAt, description, img, title, status, updatedAt }) 
   const image = { ...img, height: 70, width: 70 }
 
   return (
-    <article className='request-item'>
+    <article className='request-item margin-top'>
       <Image {...image} />
-      <div>
+      <div className='request-item-details'>
         <Title title={title} size='small' />
         <TextBox text={description} />
       </div>

--- a/src/compounds/RequestItem/RequestItem.jsx
+++ b/src/compounds/RequestItem/RequestItem.jsx
@@ -4,7 +4,6 @@ import Badge from '../../components/Badge/Badge'
 import Image from '../../components/Image/Image'
 import TextBox from '../../components/TextBox/TextBox'
 import Title from '../../components/Title/Title'
-import { img as defaultImg } from '../../resources/args'
 import './request-item.css'
 
 const RequestItem = ({ createdAt, description, img, title, status, updatedAt }) => {
@@ -38,10 +37,6 @@ RequestItem.propTypes = {
   status: Badge.propTypes,
   title: PropTypes.string.isRequired,
   updatedAt: PropTypes.string.isRequired,
-}
-
-RequestItem.defaultProps = {
-  img: defaultImg,
 }
 
 export default RequestItem

--- a/src/compounds/RequestItem/RequestItem.jsx
+++ b/src/compounds/RequestItem/RequestItem.jsx
@@ -8,11 +8,11 @@ import './request-item.css'
 
 const RequestItem = ({ createdAt, description, img, title, status, updatedAt }) => {
   const { backgroundColor, text, textColor } = status
-  img = { ...img, height: 70, width: 70 }
+  const image = { ...img, height: 70, width: 70 }
 
   return (
     <article className='request-item'>
-      <Image {...img} />
+      <Image {...image} />
       <div>
         <Title title={title} size='small' />
         <TextBox text={description} />
@@ -33,8 +33,8 @@ const RequestItem = ({ createdAt, description, img, title, status, updatedAt }) 
 RequestItem.propTypes = {
   createdAt: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired,
-  img: Image.propTypes,
-  status: Badge.propTypes,
+  img: PropTypes.shape(Image.propTypes).isRequired,
+  status: PropTypes.shape(Badge.propTypes).isRequired,
   title: PropTypes.string.isRequired,
   updatedAt: PropTypes.string.isRequired,
 }

--- a/src/compounds/RequestItem/RequestItem.jsx
+++ b/src/compounds/RequestItem/RequestItem.jsx
@@ -6,15 +6,7 @@ import TextBox from '../../components/TextBox/TextBox'
 import Title from '../../components/Title/Title'
 import './request-item.css'
 
-const RequestItem = React.forwardRef(({ createdAt, description, href, img, isLoading, title, status, updatedAt }, ref) => {
-  if (isLoading) {
-    return (
-      <div className='center-content'>
-        <ItemLoading orientation='vertical' />
-      </div>
-    )
-  }
-
+const RequestItem = React.forwardRef(({ createdAt, description, href, img, title, status, updatedAt }, ref) => {
   const { backgroundColor, text, textColor } = status
   const image = { ...img, height: 70, width: 70 }
 
@@ -43,14 +35,11 @@ const RequestItem = React.forwardRef(({ createdAt, description, href, img, isLoa
 RequestItem.propTypes = {
   createdAt: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired,
+  id: PropTypes.number,
   img: PropTypes.shape(Image.propTypes).isRequired,
   status: PropTypes.shape(Badge.propTypes).isRequired,
   title: PropTypes.string.isRequired,
   updatedAt: PropTypes.string.isRequired,
-}
-
-RequestItem.defaultProps = {
-  isLoading: false,
 }
 
 export default RequestItem

--- a/src/compounds/RequestItem/RequestItem.stories.jsx
+++ b/src/compounds/RequestItem/RequestItem.stories.jsx
@@ -13,6 +13,7 @@ export const Default = Template.bind({})
 Default.args = {
   createdAt: 'September 9, 2022',
   description: 'Does the Company offer services related to Flow Cytometry?',
+  href: '/request/F575C4',
   img: defaultImage,
   title: 'F575C4: Assay Depot Coffee Mug',
   status: {
@@ -25,6 +26,7 @@ export const Alternate = Template.bind({})
 Alternate.args = {
   createdAt: 'September 9, 2022',
   description: 'Does the Company offer services related to Flow Cytometry?',
+  href: '/request/F575C4',
   img: defaultImage,
   title: 'F575C4: Assay Depot Coffee Mug',
   status: {

--- a/src/compounds/RequestItem/RequestItem.stories.jsx
+++ b/src/compounds/RequestItem/RequestItem.stories.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import RequestItem from './RequestItem'
-import { img } from '../../resources/args'
+import { defaultImage } from '../../resources/args'
 
 export default {
   title: 'Compounds/RequestItem',
@@ -13,7 +13,7 @@ export const Default = Template.bind({})
 Default.args = {
   createdAt: 'September 9, 2022',
   description: 'Does the Company offer services related to Flow Cytometry?',
-  img,
+  img: defaultImage,
   title: 'F575C4: Assay Depot Coffee Mug',
   status: {
     text: 'Vendor Review',
@@ -25,7 +25,7 @@ export const Alternate = Template.bind({})
 Alternate.args = {
   createdAt: 'September 9, 2022',
   description: 'Does the Company offer services related to Flow Cytometry?',
-  img,
+  img: defaultImage,
   title: 'F575C4: Assay Depot Coffee Mug',
   status: {
     backgroundColor: '#DEAF17',

--- a/src/compounds/RequestItem/request-item.css
+++ b/src/compounds/RequestItem/request-item.css
@@ -1,13 +1,19 @@
 .request-item {
   display: flex;
   justify-content: space-between;
-  width: 750px;
+  width: 780px;
+  margin-bottom: 25px;
+}
+
+.request-item-details {
+  width: 380px;
 }
 
 .status {
   background-color: lightgray;
   padding: 10px;
   border-radius: 2px;
+  width: 260px;
 }
 
 .status > :first-child {

--- a/src/compounds/index.js
+++ b/src/compounds/index.js
@@ -11,6 +11,7 @@ import ItemPage from './ItemPage/ItemPage'
 import LinkGroup from './LinkGroup/LinkGroup'
 import Logo from './Logo/Logo'
 import NavLink from './NavLink/NavLink'
+import RequestItem from './RequestItem/RequestItem'
 import TitledTextBox from './TitledTextBox/TitledTextBox'
 
 export {
@@ -22,5 +23,6 @@ export {
   LinkGroup,
   Logo,
   NavLink,
+  RequestItem,
   TitledTextBox,
 }

--- a/src/resources/args.js
+++ b/src/resources/args.js
@@ -7,6 +7,7 @@ const img = {
   src: item,
   alt: 'Several rows of test tubes with a liquid being put into one.',
 }
+export { img as defaultImage }
 
 export const items = [
   {


### PR DESCRIPTION
# expected behavior
- remove the img import from the RequestItem component because it caused the rollup build to fail for some reason: "Note that you need plugins to import files that are not JavaScript"
- do not redefine the img prop in the request item component per eslint. also require the img and status props
- export the img variable as defaultImage from args.js and use it in the request item story


# demo
![image](https://user-images.githubusercontent.com/29032869/202822343-da015eda-80ea-47a5-bf40-737d28bde929.png)
