### PR TITLE
Request List Page Layout 

### DIFF
--- a/src/assets/theme/global.css
+++ b/src/assets/theme/global.css
@@ -11,8 +11,17 @@
 	margin-top: 10px;
 }
 
-.margin-vertical {
-	margin: 10px 0;
+.my-2 {
+	margin-top: 1rem;
+  margin-bottom: 1rem;
+}
+
+.ml-auto {
+	margin-left: auto;
+}
+
+.d-block {
+  display: block !important;
 }
 
 .container {

--- a/src/assets/theme/global.css
+++ b/src/assets/theme/global.css
@@ -3,8 +3,8 @@
 	padding: 0;
 }
 
-.margin-bottom {
-	margin-bottom: 10px;
+.mb-2 {
+	margin-bottom: 1rem;
 }
 
 .mt-2 {

--- a/src/assets/theme/global.css
+++ b/src/assets/theme/global.css
@@ -7,8 +7,8 @@
 	margin-bottom: 10px;
 }
 
-.margin-top {
-	margin-top: 10px;
+.mt-2 {
+	margin-top: 1rem;
 }
 
 .my-2 {

--- a/src/components/Button/Button.jsx
+++ b/src/components/Button/Button.jsx
@@ -5,12 +5,12 @@ import './button.css'
 /**
  * Primary UI component for user interaction
  */
-const Button = ({ primary, backgroundColor, size, label, ...props }) => {
+const Button = ({ primary, backgroundColor, size, label, addClass, ...props }) => {
   const mode = primary ? 'storybook-button--primary' : 'storybook-button--secondary'
   return (
     <button
       type='button'
-      className={['storybook-button', `storybook-button--${size}`, mode].join(' ')}
+      className={`storybook-button storybook-button--${size} ${mode} ${addClass}`}
       style={backgroundColor && { backgroundColor }}
       {...props}
     >
@@ -40,6 +40,7 @@ Button.propTypes = {
 	 * Optional click handler
 	 */
   onClick: PropTypes.func,
+  addClass: PropTypes.string,
 }
 
 Button.defaultProps = {
@@ -47,6 +48,7 @@ Button.defaultProps = {
   primary: false,
   size: 'medium',
   onClick: undefined,
+  addClass: '',
 }
 
 export default Button

--- a/src/components/Title/Title.jsx
+++ b/src/components/Title/Title.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import './title.css'
 
 const Title = ({ alignment, size, style, title }) => (
-  <div className={`title--${alignment} margin-bottom`}>
+  <div className={`title--${alignment} mb-2`}>
     <h1
       className={`title title--${size}`}
       style={{ ...style }}

--- a/src/compounds/Item/Item.jsx
+++ b/src/compounds/Item/Item.jsx
@@ -40,12 +40,12 @@ const Item = React.forwardRef(({ buttonLink, buttonProps, imgProps, isLoading, i
         <div className='item-details'>
           {withTitleLink ? (
             <a href={titleLink} ref={ref} className='pointer-cursor link'>
-              <h3 className='item-name margin-top'>
+              <h3 className='item-name mt-2'>
                 {name}
               </h3>
             </a>
           ) : (
-            <h3 className='item-name margin-top'>
+            <h3 className='item-name mt-2'>
               {name}
             </h3>
           )}

--- a/src/compounds/Item/Item.jsx
+++ b/src/compounds/Item/Item.jsx
@@ -50,7 +50,7 @@ const Item = React.forwardRef(({ buttonLink, buttonProps, imgProps, isLoading, i
             </h3>
           )}
           {description && (
-            <p className='item-description margin-vertical'>
+            <p className='item-description my-2'>
               {/* TODO(alishaevn): account for really long descriptions */}
               {description}
             </p>

--- a/src/compounds/LinkGroup/LinkGroup.jsx
+++ b/src/compounds/LinkGroup/LinkGroup.jsx
@@ -5,7 +5,7 @@ import './link-group.css'
 
 const LinkGroup = ({ header, headerStyle, links, linkStyle }) => (
   <div className='link-group-container'>
-    <p className='link-group-header margin-bottom' style={headerStyle}>{header}</p>
+    <p className='link-group-header mb-2' style={headerStyle}>{header}</p>
     {links.map(({ name, url }) => <Link href={url} key={name} label={name} addClass='link-group-links' style={linkStyle} />)}
   </div>
 )

--- a/src/compounds/RequestItem/RequestItem.jsx
+++ b/src/compounds/RequestItem/RequestItem.jsx
@@ -11,7 +11,7 @@ const RequestItem = React.forwardRef(({ createdAt, description, href, img, title
   const image = { ...img, height: 70, width: 70 }
 
   return (
-    <article className='request-item margin-top'>
+    <article className='request-item mt-2'>
       <Image {...image} />
       <div className='request-item-details'>
         <a href={href} ref={ref} className='link pointer-cursor'>

--- a/src/compounds/RequestItem/request-item.css
+++ b/src/compounds/RequestItem/request-item.css
@@ -2,7 +2,7 @@
   display: flex;
   justify-content: space-between;
   margin-bottom: 25px;
-  gap: 20px
+  gap: 30px
 }
 
 .request-item-details {
@@ -13,7 +13,7 @@
   background-color: lightgray;
   padding: 10px;
   border-radius: 2px;
-  flex: 1;
+  width: 260px;
 }
 
 .status > :first-child {

--- a/src/compounds/RequestItem/request-item.css
+++ b/src/compounds/RequestItem/request-item.css
@@ -1,19 +1,19 @@
 .request-item {
   display: flex;
   justify-content: space-between;
-  width: 780px;
   margin-bottom: 25px;
+  gap: 20px
 }
 
 .request-item-details {
-  width: 380px;
+  flex: 2
 }
 
 .status {
   background-color: lightgray;
   padding: 10px;
   border-radius: 2px;
-  width: 260px;
+  flex: 1;
 }
 
 .status > :first-child {

--- a/src/compounds/RequestList/RequestList.jsx
+++ b/src/compounds/RequestList/RequestList.jsx
@@ -6,7 +6,7 @@ import Title from '../../components/Title/Title'
 import RequestItem from '../RequestItem/RequestItem'
 
 const RequestList = ({ requests, isLoading }) => (
-  <>
+  <div className='center-content'>
     <Title title='My Requests' size='medium' />
     {isLoading
       ? (
@@ -25,7 +25,7 @@ const RequestList = ({ requests, isLoading }) => (
           </Link>
         ))
       )}
-  </>
+  </div>
 )
 
 RequestList.propTypes = {

--- a/src/compounds/RequestList/RequestList.jsx
+++ b/src/compounds/RequestList/RequestList.jsx
@@ -6,7 +6,7 @@ import Title from '../../components/Title/Title'
 import RequestItem from '../RequestItem/RequestItem'
 
 const RequestList = ({ requests, isLoading }) => (
-  <div className='center-content'>
+  <>
     <Title title='My Requests' size='medium' />
     {isLoading
       ? (
@@ -25,7 +25,7 @@ const RequestList = ({ requests, isLoading }) => (
           </Link>
         ))
       )}
-  </div>
+    </>
 )
 
 RequestList.propTypes = {


### PR DESCRIPTION
# Summary
- formats request list page so that the requests will be the correct width inside their flexbox
- changes a few margin class names so they are consistent to what they will be with bootstrap
- adds an additional classes (`addClass`) prop to buttons

# Related
https://github.com/scientist-softserv/webstore/pull/58

# Screenshot
<img width="1659" alt="image" src="https://user-images.githubusercontent.com/73361970/203358616-f70300b2-5315-4a3e-b292-ad93e4ae7349.png">

