### PR TITLE
85-refactor-request-stats

### DIFF
--- a/src/compounds/RequestStats/RequestStats.jsx
+++ b/src/compounds/RequestStats/RequestStats.jsx
@@ -10,7 +10,7 @@ const RequestStats = ({ billingInfo, createdAt, deadline, shippingInfo }) => {
   return (
     <Card className='request-stats w-25'>
       <Card.Header>
-        <Card.Title>Request Info</Card.Title>
+        <Card.Title className='mb-0'>Request Info</Card.Title>
       </Card.Header>
       <Card.Body>
         <Card.Subtitle>Date of request</Card.Subtitle>

--- a/src/compounds/RequestStats/RequestStats.jsx
+++ b/src/compounds/RequestStats/RequestStats.jsx
@@ -3,13 +3,13 @@ import { Card } from 'react-bootstrap'
 import PropTypes from 'prop-types'
 import './request-stats.css'
 
-const RequestStats = ({ billingInfo, createdAt, deadline, shippingInfo }) => {
+const RequestStats = ({ addClass, billingInfo, createdAt, deadline, shippingInfo }) => {
   const shippingAddress = shippingInfo.address.split(/\n/)
   const billingAddress = billingInfo.address.split(/\n/)
 
   return (
     <Card className='request-stats w-25'>
-      <Card.Header>
+      <Card.Header className={`${addClass}`}>
         <Card.Title className='mb-0'>Request Info</Card.Title>
       </Card.Header>
       <Card.Body>
@@ -41,6 +41,7 @@ const RequestStats = ({ billingInfo, createdAt, deadline, shippingInfo }) => {
 }
 
 RequestStats.propTypes = {
+  addClass: PropTypes.string,
   billingInfo: PropTypes.shape({
     address: PropTypes.string.isRequired,
     id: PropTypes.number.isRequired,
@@ -54,6 +55,7 @@ RequestStats.propTypes = {
 }
 
 RequestStats.defaultProps = {
+  addClass: '',
   deadline: '',
 }
 

--- a/src/compounds/RequestStats/RequestStats.jsx
+++ b/src/compounds/RequestStats/RequestStats.jsx
@@ -1,56 +1,48 @@
 import React from 'react'
+import { Card } from 'react-bootstrap'
 import PropTypes from 'prop-types'
-import TextBox from '../../components/TextBox/TextBox'
-import Title from '../../components/Title/Title'
 import './request-stats.css'
 
-const RequestStats = ({ billingAddress, createdAt, deadline, detailsColor, projectCode, shippingAddress, headerColor }) => {
-  const titleStyle = { color: headerColor }
-  const textStyle = { color: detailsColor }
+const RequestStats = ({ billingAddress, createdAt, deadline, shippingAddress }) => {
+  const shippingLines = shippingAddress.split(/\n/)
+  const billingLines = billingAddress.split(/\n/)
 
   return (
-  <article className='request-stats'>
-    <div className='mb-2'>
-      <Title title='Request Info' size='small' />
-    </div>
-    <div className='mb-2'>
-      <Title title='Date of request' size='x-small' style={titleStyle} />
-      <TextBox text={createdAt} style={textStyle} />
-    </div>
-    <div className='mb-2'>
-      <Title title='Proposals required by' size='x-small' style={titleStyle} />
-      <TextBox text={deadline} style={textStyle} />
-    </div>
-    <div className='mb-2'>
-      <Title title='Project code' size='x-small' style={titleStyle} />
-      <TextBox text={projectCode} style={textStyle} />
-    </div>
-    <div className='mb-2'>
-      <Title title='Shipping address' size='x-small' style={titleStyle} />
-      <TextBox text={shippingAddress} style={textStyle} />
-    </div>
-    <div>
-      <Title title='Billing address' size='x-small' style={titleStyle} />
-      <TextBox text={billingAddress} style={textStyle} />
-    </div>
-  </article>
-)}
+    <Card className='w-25'>
+      <Card.Header>
+        <Card.Title>Request Info</Card.Title>
+      </Card.Header>
+      <Card.Body>
+        <Card.Subtitle>Date of request</Card.Subtitle>
+        <Card.Text className='mb-4'>{createdAt}</Card.Text>
+        <Card.Subtitle>Proposals required by</Card.Subtitle>
+        <Card.Text className='mb-4'>{deadline}</Card.Text>
+        <Card.Subtitle>Shipping Address</Card.Subtitle>
+        {shippingLines.map((line, index) => (
+          <Card.Text className={`${(index === shippingLines.length-1) ? 'mb-4' : 'mb-0'}`}>
+            {line}
+          </Card.Text>)
+        )}
+        <Card.Subtitle>Billing Address</Card.Subtitle>
+        {billingLines.map((line, index) => (
+          <Card.Text className={`${(index === billingLines.length-1) ? '' : 'mb-0'}`}>
+            {line}
+          </Card.Text>)
+        )}
+      </Card.Body>
+    </Card>
+  )
+}
 
 RequestStats.propTypes = {
   billingAddress: PropTypes.string.isRequired,
   createdAt: PropTypes.string.isRequired,
   deadline: PropTypes.string,
-  detailsColor: PropTypes.string,
-  headerColor: PropTypes.string,
-  projectCode: PropTypes.string,
   shippingAddress: PropTypes.string.isRequired,
 }
 
 RequestStats.defaultProps = {
   deadline: '',
-  detailsColor: '#999999',
-  headerColor: '#333333',
-  projectCode: '',
 }
 
 export default RequestStats

--- a/src/compounds/RequestStats/RequestStats.jsx
+++ b/src/compounds/RequestStats/RequestStats.jsx
@@ -3,12 +3,12 @@ import { Card } from 'react-bootstrap'
 import PropTypes from 'prop-types'
 import './request-stats.css'
 
-const RequestStats = ({ billingAddress, createdAt, deadline, shippingAddress }) => {
-  const shippingLines = shippingAddress.split(/\n/)
-  const billingLines = billingAddress.split(/\n/)
+const RequestStats = ({ billingInfo, createdAt, deadline, shippingInfo }) => {
+  const shippingAddress = shippingInfo.address.split(/\n/)
+  const billingAddress = billingInfo.address.split(/\n/)
 
   return (
-    <Card className='w-25'>
+    <Card className='request-stats w-25'>
       <Card.Header>
         <Card.Title>Request Info</Card.Title>
       </Card.Header>
@@ -18,27 +18,39 @@ const RequestStats = ({ billingAddress, createdAt, deadline, shippingAddress }) 
         <Card.Subtitle>Proposals required by</Card.Subtitle>
         <Card.Text className='mb-4'>{deadline}</Card.Text>
         <Card.Subtitle>Shipping Address</Card.Subtitle>
-        {shippingLines.map((line, index) => (
-          <Card.Text className={`${(index === shippingLines.length-1) ? 'mb-4' : 'mb-0'}`}>
+        {shippingAddress.map((line, index) => (
+          <Card.Text
+            key={shippingInfo.id}
+            className={`${(index === shippingAddress.length - 1) ? 'mb-4' : 'mb-0'}`}
+          >
             {line}
-          </Card.Text>)
-        )}
+          </Card.Text>
+        ))}
         <Card.Subtitle>Billing Address</Card.Subtitle>
-        {billingLines.map((line, index) => (
-          <Card.Text className={`${(index === billingLines.length-1) ? '' : 'mb-0'}`}>
+        {billingAddress.map((line, index) => (
+          <Card.Text
+            key={billingInfo.id}
+            className={`${(index === billingAddress.length - 1) ? '' : 'mb-0'}`}
+          >
             {line}
-          </Card.Text>)
-        )}
+          </Card.Text>
+        ))}
       </Card.Body>
     </Card>
   )
 }
 
 RequestStats.propTypes = {
-  billingAddress: PropTypes.string.isRequired,
+  billingInfo: PropTypes.shape({
+    address: PropTypes.string.isRequired,
+    id: PropTypes.number.isRequired,
+  }).isRequired,
   createdAt: PropTypes.string.isRequired,
   deadline: PropTypes.string,
-  shippingAddress: PropTypes.string.isRequired,
+  shippingInfo: PropTypes.shape({
+    address: PropTypes.string.isRequired,
+    id: PropTypes.number.isRequired,
+  }).isRequired,
 }
 
 RequestStats.defaultProps = {

--- a/src/compounds/RequestStats/RequestStats.stories.jsx
+++ b/src/compounds/RequestStats/RequestStats.stories.jsx
@@ -11,9 +11,9 @@ const Template = (args) => <RequestStats {...args} />
 
 export const Default = Template.bind({})
 Default.args = {
-  billingAddress: shipTo.text,
+  billingInfo: { address: shipTo.text, id: shipTo.id },
   createdAt: 'September 9, 2022',
   deadline: 'September 17, 2022',
   projectCode: '',
-  shippingAddress: shipTo.text,
+  shippingInfo: { address: shipTo.text, id: shipTo.id },
 }

--- a/src/compounds/RequestStats/request-stats.css
+++ b/src/compounds/RequestStats/request-stats.css
@@ -1,6 +1,3 @@
 .request-stats {
-  border: 1px solid #999999;
-  width: fit-content;
-  padding: 25px;
-  border-radius: 5px;
+  min-width: fit-content;
 }


### PR DESCRIPTION
# expected behavior
- using the react bs card component to render request stats
- remove the detailsColor, headerColor and projectCode props
  - [chris said](https://assaydepot.slack.com/archives/C03FZDALABG/p1670007670770879) we don't need project code
  - the color props aren't needed since we're using bootstrap
- add an `addClass` prop so the header can be styled
- pass in a billing and shipping object that has the id and address so the id can be used as a unique key value

# demo

https://user-images.githubusercontent.com/29032869/206732739-d384e96c-d3af-4b83-892e-efc0dc84d592.mp4