### PR TITLE
Request attachments

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,7 +20,7 @@
     "indent": ["error", 2],
     "jsx-a11y/click-events-have-key-events": [1],
     "jsx-quotes": ["error", "prefer-single"],
-    "max-len": ["error", { "code": 120 }],
+    "max-len": ["error", { "code": 140 }],
     "object-curly-newline": ["error", {
       "ImportDeclaration": { "multiline": true, "minProperties": 4 },
       "ExportDeclaration": { "multiline": true, "minProperties": 4 }

--- a/src/components/AdditionalInfo/AdditionalInfo.jsx
+++ b/src/components/AdditionalInfo/AdditionalInfo.jsx
@@ -1,12 +1,36 @@
-import React, { useState } from 'react'
-import { Card, Form } from 'react-bootstrap'
+import React, { useState, useRef } from 'react'
 import PropTypes from 'prop-types'
+import { Card, CloseButton, Form, ListGroup } from 'react-bootstrap'
+import { convertToBase64 } from '../../resources/utilityFunctions'
 
 const AdditionalInfo = ({ updateRequestForm }) => {
   const [showProposalDate, setShowProposalDate] = useState(true)
+  const [files, setFiles] = useState([])
   const today = new Date().toISOString().slice(0, 10)
+  const fileRef = useRef(null)
   const handleChange = (value) => {
     updateRequestForm(value, 'proposedDeadline')
+  }
+
+  const handleAddFile = async (event) => {
+    event.preventDefault()
+    try {
+      // "event.target.files" returns a FileList, which looks like an array but does not respond to array methods
+      // except "length". we are using the spread syntax to set "files" to be an iterable array
+      const fileArray = [...event.target.files]
+      const newBase64Files = await Promise.all(convertToBase64(fileArray))
+      const newFiles = fileArray.map((file, index) => ({ [file.name]: newBase64Files[index] }))
+
+      setFiles([...files, ...newFiles])
+      fileRef.current.value = ''
+    } catch (error) {
+      throw new Error(error)
+    }
+  }
+
+  const handleDeleteFile = (file) => {
+    const remainingFiles = files.filter((obj) => obj !== file)
+    setFiles(remainingFiles)
   }
 
   return (
@@ -46,8 +70,25 @@ const AdditionalInfo = ({ updateRequestForm }) => {
         Currently we have an open question in slack */}
         <Form.Group controlId='attachments' className='mb-3'>
           <Form.Label>Attachments:</Form.Label>
-          <Form.Control type='file' multiple />
+          <Form.Control
+            multiple
+            type='file'
+            onChange={handleAddFile}
+            ref={fileRef}
+          />
         </Form.Group>
+        <ListGroup variant='flush'>
+          {files.map((file) => {
+            const fileName = Object.keys(file)[0]
+
+            return (
+              <ListGroup.Item key={fileName} className='d-flex align-items-center'>
+                <span>{fileName}</span>
+                <CloseButton onClick={() => handleDeleteFile(file)} className='ms-auto' />
+              </ListGroup.Item>
+            )
+          })}
+        </ListGroup>
       </Card.Body>
     </Card>
   )

--- a/src/components/AdditionalInfo/AdditionalInfo.jsx
+++ b/src/components/AdditionalInfo/AdditionalInfo.jsx
@@ -1,13 +1,16 @@
 import React, { useState, useRef } from 'react'
 import PropTypes from 'prop-types'
-import { Card, CloseButton, Form, ListGroup } from 'react-bootstrap'
-import { convertToBase64 } from '../../resources/utilityFunctions'
+import {
+  Card, CloseButton, Form, ListGroup,
+} from 'react-bootstrap'
+import { convertToBase64, apiV2CompatibleStrings } from '../../resources/utilityFunctions'
 
 const AdditionalInfo = ({ updateRequestForm }) => {
   const [showProposalDate, setShowProposalDate] = useState(true)
   const [files, setFiles] = useState([])
   const today = new Date().toISOString().slice(0, 10)
   const fileRef = useRef(null)
+
   const handleChange = (value) => {
     updateRequestForm(value, 'proposedDeadline')
   }
@@ -22,6 +25,7 @@ const AdditionalInfo = ({ updateRequestForm }) => {
       const newFiles = fileArray.map((file, index) => ({ [file.name]: newBase64Files[index] }))
 
       setFiles([...files, ...newFiles])
+      updateRequestForm(apiV2CompatibleStrings([...files, ...newFiles]), 'attachments')
       fileRef.current.value = ''
     } catch (error) {
       throw new Error(error)
@@ -31,6 +35,7 @@ const AdditionalInfo = ({ updateRequestForm }) => {
   const handleDeleteFile = (file) => {
     const remainingFiles = files.filter((obj) => obj !== file)
     setFiles(remainingFiles)
+    updateRequestForm(apiV2CompatibleStrings(remainingFiles), 'attachments')
   }
 
   return (

--- a/src/compounds/ActionsGroup/actions/SendMessage.jsx
+++ b/src/compounds/ActionsGroup/actions/SendMessage.jsx
@@ -8,7 +8,7 @@ import {
   ListGroup,
   Modal,
 } from 'react-bootstrap'
-import { convertToBase64 } from '../../../resources/utilityFunctions'
+import { apiV2CompatibleStrings, convertToBase64 } from '../../../resources/utilityFunctions'
 import './styles.scss'
 
 const SendMessage = ({ onSubmit, handleClose }) => {
@@ -18,9 +18,7 @@ const SendMessage = ({ onSubmit, handleClose }) => {
 
   const handleSubmit = (event) => {
     event.preventDefault()
-    // api v2 wants a string that has a "name" property on it so we are manually adding it here
-    const apiV2CompatibleStrings = files.map((file) => `${Object.values(file)[0]};name=${Object.keys(file)[0]};`)
-    onSubmit({ message: messageRef.current.value, files: apiV2CompatibleStrings })
+    onSubmit({ message: messageRef.current.value, files: apiV2CompatibleStrings(files) })
     handleClose()
   }
 

--- a/src/resources/utilityFunctions.js
+++ b/src/resources/utilityFunctions.js
@@ -1,3 +1,8 @@
+// the following 3 functions are used in the AdditionalInfo & SendMessage components
+
+// api v2 wants a string that has a "name" property on it so we are manually adding it here
+export const apiV2CompatibleStrings = (files) => files.map((file) => `${Object.values(file)[0]};name=${Object.keys(file)[0]};`)
+
 export const convertToBase64 = (fileArray) => fileArray.map((file) => new Promise((resolve, reject) => {
   const fileReader = new FileReader()
   fileReader.readAsDataURL(file)

--- a/src/resources/utilityFunctions.js
+++ b/src/resources/utilityFunctions.js
@@ -1,4 +1,4 @@
-// the following 3 functions are used in the AdditionalInfo & SendMessage components
+// the following 2 functions are used in the AdditionalInfo & SendMessage components
 
 // api v2 wants a string that has a "name" property on it so we are manually adding it here
 export const apiV2CompatibleStrings = (files) => files.map((file) => `${Object.values(file)[0]};name=${Object.keys(file)[0]};`)


### PR DESCRIPTION
# Summary
brings the UI from the message attachments into the Additional Info component that is used on the request forms

# Related
https://github.com/scientist-softserv/webstore-component-library/issues/106

# Notes
When attachments are uploaded (on both messages and request forms) there is text that says "No file chosen"
- this is built into bootstrap 
- I left a comment/question on a related BS issue here, so if they respond we can follow up and change this: https://github.com/twbs/bootstrap/discussions/33880#discussioncomment-4606560