### PR TITLE
Add minimum date of a day and default date of a week

### DIFF
--- a/src/components/AdditionalInfo/AdditionalInfo.jsx
+++ b/src/components/AdditionalInfo/AdditionalInfo.jsx
@@ -3,13 +3,14 @@ import PropTypes from 'prop-types'
 import {
   Card, CloseButton, Form, ListGroup,
 } from 'react-bootstrap'
-import { convertToBase64, apiV2CompatibleStrings } from '../../resources/utilityFunctions'
+import { addDays, apiV2CompatibleStrings, convertToBase64 } from '../../resources/utilityFunctions'
 
 const AdditionalInfo = ({ updateRequestForm }) => {
   const [showProposalDate, setShowProposalDate] = useState(true)
   const [files, setFiles] = useState([])
-  const today = new Date().toISOString().slice(0, 10)
   const fileRef = useRef(null)
+  const oneWeekFromNow = addDays((new Date()), 7).toISOString().slice(0, 10)
+  const oneDayFromNow = addDays((new Date()), 1).toISOString().slice(0, 10)
 
   const handleChange = (value) => {
     updateRequestForm(value, 'proposedDeadline')
@@ -52,7 +53,8 @@ const AdditionalInfo = ({ updateRequestForm }) => {
               <Form.Control
                 className='prevent-validation-styles'
                 type='date'
-                min={today}
+                min={oneDayFromNow}
+                defaultValue={oneWeekFromNow}
                 placeholder='Proposals Required By'
                 disabled={showProposalDate === false}
                 onChange={showProposalDate && ((e) => handleChange(e.target.value))}

--- a/src/resources/utilityFunctions.js
+++ b/src/resources/utilityFunctions.js
@@ -10,7 +10,7 @@ export const convertToBase64 = (fileArray) => fileArray.map((file) => new Promis
   fileReader.onerror = (error) => reject(new Error(error))
 }))
 
-// used to add days to a Date () in the AdditionalInfo component
+// used to add days to a new Date() in the AdditionalInfo component
 export const addDays = (date, days) => {
   date.setDate(date.getDate() + days)
   return date

--- a/src/resources/utilityFunctions.js
+++ b/src/resources/utilityFunctions.js
@@ -12,6 +12,6 @@ export const convertToBase64 = (fileArray) => fileArray.map((file) => new Promis
 
 // used to add days to a Date () in the AdditionalInfo component
 export const addDays = (date, days) => {
-  date.setDate(date.getDate() + days);
-  return date;
+  date.setDate(date.getDate() + days)
+  return date
 }

--- a/src/resources/utilityFunctions.js
+++ b/src/resources/utilityFunctions.js
@@ -9,3 +9,9 @@ export const convertToBase64 = (fileArray) => fileArray.map((file) => new Promis
   fileReader.onload = () => resolve(fileReader.result)
   fileReader.onerror = (error) => reject(new Error(error))
 }))
+
+// used to add days to a Date () in the AdditionalInfo component
+export const addDays = (date, days) => {
+  date.setDate(date.getDate() + days);
+  return date;
+}


### PR DESCRIPTION
# Summary
- The datepicker in the additional info component will now have a minimum date of one day
- The default date when a user opens the date picker will now be one week

# Video
https://share.getcloudapp.com/4gu4eyL0