### PR TITLE
repair the broken linking

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "webstore-component-library",
+  "name": "@scientist-softserv/webstore-component-library",
   "version": "0.0.0",
   "description": "A React component library intended for use with WebStore applications",
   "main": "dist/index.js",


### PR DESCRIPTION
# story
now that we are using the published package in the webstore, the local linking doesn't work as outlined in the [webstore readme](https://github.com/scientist-softserv/webstore#component-library-dev-mode).

# expected behavior
- rename the package so it matches the published package name