### PR TITLE
remove fromItemGroup

### DIFF
--- a/src/compounds/Item/CardBody.jsx
+++ b/src/compounds/Item/CardBody.jsx
@@ -5,7 +5,7 @@ import Link from '../../components/Link/Link'
 import NextLink from '../../components/NextLink/NextLink'
 import LinkedButton from '../LinkedButton/LinkedButton'
 
-const CardBody = ({ buttonLink, buttonProps, fromItemGroup, item,
+const CardBody = ({ buttonLink, buttonProps, item,
   orientation, titleLink, withButtonLink, withTitleLink }) => {
   const { id, description, name } = item
 
@@ -14,15 +14,12 @@ const CardBody = ({ buttonLink, buttonProps, fromItemGroup, item,
       <div className={orientation === 'horizontal' ? 'd-block d-md-flex align-items-center justify-content-between' : ''}>
         <div className={orientation === 'horizontal' ? 'me-2' : ''}>
           <Card.Title>
-            {(withTitleLink && fromItemGroup) && (
+            {(withTitleLink) && (
               <NextLink
                 text={name}
                 path={{ pathname: titleLink, query: { id } }}
                 addClass='text-decoration-none link-hover'
               />
-            )}
-            {(withTitleLink && !fromItemGroup) && (
-              <Link label={name} addClass='text-decoration-none link-hover' href={titleLink} />
             )}
             {(!withTitleLink) && (
               name
@@ -58,7 +55,6 @@ CardBody.propTypes = {
   // buttonProps: props => props.withButtonLink
   // ? PropTypes.shape(Button.propTypes)
   // : PropTypes.shape({ ...Button.propTypes, label: PropTypes.string })
-  fromItemGroup: PropTypes.bool,
   item: PropTypes.shape({
     description: PropTypes.string,
     id: PropTypes.number.isRequired,
@@ -78,7 +74,6 @@ CardBody.propTypes = {
 CardBody.defaultProps = {
   buttonLink: '',
   buttonProps: LinkedButton.defaultProps,
-  fromItemGroup: false,
   item: {
     description: '',
   },

--- a/src/compounds/Item/Item.jsx
+++ b/src/compounds/Item/Item.jsx
@@ -7,7 +7,7 @@ import LinkedButton from '../LinkedButton/LinkedButton'
 import ItemLoading from './ItemLoading'
 import './item.scss'
 
-const Item = ({ buttonLink, buttonProps, href, fromItemGroup, isLoading, item, orientation, titleLink, withButtonLink,
+const Item = ({ buttonLink, buttonProps, href, isLoading, item, orientation, titleLink, withButtonLink,
   withTitleLink, width }) => {
   if (isLoading) {
     return (
@@ -43,7 +43,6 @@ const Item = ({ buttonLink, buttonProps, href, fromItemGroup, isLoading, item, o
             <CardBody
               buttonLink={link}
               buttonProps={buttonProps}
-              fromItemGroup={fromItemGroup}
               item={item}
               orientation={orientation}
               titleLink={link}
@@ -62,7 +61,6 @@ const Item = ({ buttonLink, buttonProps, href, fromItemGroup, isLoading, item, o
           <CardBody
             buttonLink={link}
             buttonProps={buttonProps}
-            fromItemGroup={fromItemGroup}
             item={item}
             orientation={orientation}
             titleLink={link}
@@ -100,7 +98,6 @@ Item.propTypes = {
     name: PropTypes.string.isRequired,
     slug: PropTypes.string,
   }),
-  fromItemGroup: PropTypes.bool,
   orientation: PropTypes.oneOf(['horizontal', 'vertical']),
   titleLink: PropTypes.string,
   withButtonLink: PropTypes.bool,
@@ -111,7 +108,6 @@ Item.propTypes = {
 Item.defaultProps = {
   buttonLink: '',
   buttonProps: LinkedButton.defaultProps,
-  fromItemGroup: false,
   href: '',
   isLoading: false,
   item: {

--- a/src/compounds/ItemGroup/ItemGroup.jsx
+++ b/src/compounds/ItemGroup/ItemGroup.jsx
@@ -38,7 +38,6 @@ const ItemGroup = ({ buttonProps, items, isLoading, orientation, withButtonLink,
                 withButtonLink={withButtonLink}
                 withTitleLink={withTitleLink}
                 href={item.href}
-                fromItemGroup={true}
               />
             </Col>
           ))


### PR DESCRIPTION
# story
the `fromItemGroup` prop is no longer necessary because we need to pass the `id` as a query param in both instances of the `Item` component

# expected behavior
- remove the no longer needed `fromItemGroup` prop