### PR TITLE
93-no-proposed-deadline

### DIFF
--- a/src/components/AdditionalInfo/AdditionalInfo.jsx
+++ b/src/components/AdditionalInfo/AdditionalInfo.jsx
@@ -74,7 +74,7 @@ const AdditionalInfo = ({ defaultRequiredDate, updateRequestForm }) => {
             label='Proposals can be submitted at any time.'
             onChange={() => {
               setShowProposalDate(!showProposalDate)
-              if (showProposalDate) handleChange(null)
+              if (showProposalDate) handleChange('')
             }}
           />
         </Form.Group>


### PR DESCRIPTION
# story
the `proposed_deadline_str` property that we send to the api when creating a request expects a string. in the event the user has selected that there isn't a proposal deadline, we want to send back an empty string instead of `null`.