### PR TITLE
131 hide featured service page

### DIFF
--- a/src/compounds/Item/CardBody.jsx
+++ b/src/compounds/Item/CardBody.jsx
@@ -1,14 +1,13 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import Card from 'react-bootstrap/card'
-import Link from '../../components/Link/Link'
 import NextLink from '../../components/NextLink/NextLink'
 import LinkedButton from '../LinkedButton/LinkedButton'
 
 const CardBody = ({ buttonLink, buttonProps, item,
-  orientation, titleLink, withButtonLink, withTitleLink }) => {
-  const { id, description, name } = item
-
+  orientation, showServicePage, titleLink, withButtonLink, withTitleLink }) => {
+  const { id, description, name, slug } = item
+  
   return (
     <Card.Body className={withButtonLink && 'd-flex flex-column'}>
       <div className={orientation === 'horizontal' ? 'd-block d-md-flex align-items-center justify-content-between' : ''}>
@@ -17,7 +16,7 @@ const CardBody = ({ buttonLink, buttonProps, item,
             {(withTitleLink) && (
               <NextLink
                 text={name}
-                path={{ pathname: titleLink, query: { id } }}
+                path={showServicePage ? { pathname: titleLink, query: { id } } : { pathname: `/requests/new/${slug}`, query: { id } }}
                 addClass='text-decoration-none link-hover'
               />
             )}
@@ -66,6 +65,7 @@ CardBody.propTypes = {
     slug: PropTypes.string,
   }),
   orientation: PropTypes.oneOf(['horizontal', 'vertical']),
+  showServicePage: PropTypes.bool.isRequired,
   titleLink: PropTypes.string,
   withButtonLink: PropTypes.bool,
   withTitleLink: PropTypes.bool,

--- a/src/compounds/Item/CardBody.jsx
+++ b/src/compounds/Item/CardBody.jsx
@@ -7,7 +7,7 @@ import LinkedButton from '../LinkedButton/LinkedButton'
 const CardBody = ({ buttonLink, buttonProps, item,
   orientation, showServicePage, titleLink, withButtonLink, withTitleLink }) => {
   const { id, description, name, slug } = item
-  
+
   return (
     <Card.Body className={withButtonLink && 'd-flex flex-column'}>
       <div className={orientation === 'horizontal' ? 'd-block d-md-flex align-items-center justify-content-between' : ''}>
@@ -35,7 +35,7 @@ const CardBody = ({ buttonLink, buttonProps, item,
             <LinkedButton
               addClass={`item-button-${orientation} item-link mt-auto`}
               buttonProps={buttonProps}
-              path={{ pathname: buttonLink, query: { id }}}
+              path={{ pathname: buttonLink, query: { id } }}
             />
           </div>
         )}

--- a/src/compounds/Item/Item.jsx
+++ b/src/compounds/Item/Item.jsx
@@ -7,7 +7,7 @@ import LinkedButton from '../LinkedButton/LinkedButton'
 import ItemLoading from './ItemLoading'
 import './item.scss'
 
-const Item = ({ buttonLink, buttonProps, href, isLoading, item, orientation, showServicePage, titleLink, 
+const Item = ({ buttonLink, buttonProps, href, isLoading, item, orientation, showServicePage, titleLink,
   withButtonLink, withTitleLink, width }) => {
   if (isLoading) {
     return (

--- a/src/compounds/Item/Item.jsx
+++ b/src/compounds/Item/Item.jsx
@@ -7,8 +7,8 @@ import LinkedButton from '../LinkedButton/LinkedButton'
 import ItemLoading from './ItemLoading'
 import './item.scss'
 
-const Item = ({ buttonLink, buttonProps, href, isLoading, item, orientation, titleLink, withButtonLink,
-  withTitleLink, width }) => {
+const Item = ({ buttonLink, buttonProps, href, isLoading, item, orientation, showServicePage, titleLink, 
+  withButtonLink, withTitleLink, width }) => {
   if (isLoading) {
     return (
       <>
@@ -45,6 +45,7 @@ const Item = ({ buttonLink, buttonProps, href, isLoading, item, orientation, tit
               buttonProps={buttonProps}
               item={item}
               orientation={orientation}
+              showServicePage={showServicePage}
               titleLink={link}
               withButtonLink={withButtonLink}
               withTitleLink={withTitleLink}
@@ -63,6 +64,7 @@ const Item = ({ buttonLink, buttonProps, href, isLoading, item, orientation, tit
             buttonProps={buttonProps}
             item={item}
             orientation={orientation}
+            showServicePage={showServicePage}
             titleLink={link}
             withButtonLink={withButtonLink}
             withTitleLink={withTitleLink}
@@ -99,6 +101,7 @@ Item.propTypes = {
     slug: PropTypes.string,
   }),
   orientation: PropTypes.oneOf(['horizontal', 'vertical']),
+  showServicePage: PropTypes.bool.isRequired,
   titleLink: PropTypes.string,
   withButtonLink: PropTypes.bool,
   withTitleLink: PropTypes.bool,

--- a/src/compounds/Item/Item.stories.jsx
+++ b/src/compounds/Item/Item.stories.jsx
@@ -29,6 +29,7 @@ Default.args = {
   titleLink: '/',
   orientation: 'vertical',
   style: {},
+  showServicePage: false,
   withButtonLink: false,
   withTitleLink: false,
 }

--- a/src/compounds/ItemGroup/ItemGroup.jsx
+++ b/src/compounds/ItemGroup/ItemGroup.jsx
@@ -6,7 +6,7 @@ import Item from '../Item/Item'
 import ItemLoading from '../Item/ItemLoading'
 import './item-group.scss'
 
-const ItemGroup = ({ buttonProps, items, isLoading, orientation, withButtonLink, withTitleLink }) => (
+const ItemGroup = ({ buttonProps, items, isLoading, orientation, showServicePage, withButtonLink, withTitleLink }) => (
   <>
     <Title addClass='mb-2' size='large' title='Featured Services' />
     <Row xs={1} sm={2} className={`g-5 mb-5 ${orientation === 'vertical' && 'row-cols-md-3'}`}>
@@ -35,6 +35,7 @@ const ItemGroup = ({ buttonProps, items, isLoading, orientation, withButtonLink,
                 buttonProps={buttonProps}
                 item={item}
                 orientation={orientation}
+                showServicePage={showServicePage}
                 withButtonLink={withButtonLink}
                 withTitleLink={withTitleLink}
                 href={item.href}
@@ -58,6 +59,7 @@ ItemGroup.propTypes = {
     style: PropTypes.shape({}),
   })).isRequired,
   isLoading: PropTypes.bool.isRequired,
+  showServicePage: PropTypes.bool.isRequired,
   orientation: PropTypes.oneOf(['horizontal', 'vertical']),
   withButtonLink: PropTypes.bool,
   withTitleLink: PropTypes.bool,

--- a/src/compounds/ItemGroup/ItemGroup.stories.jsx
+++ b/src/compounds/ItemGroup/ItemGroup.stories.jsx
@@ -17,6 +17,7 @@ Default.args = {
   },
   items: items.slice(0, 3),
   orientation: 'vertical',
+  showServicePage: false,
 }
 
 export const Horizontal = Template.bind({})


### PR DESCRIPTION
## summary
- this PR adds a constant variable that makes the service page optional

## 
video
 https://share.getcloudapp.com/7KujnqXp
 
 
## acceptance criteria
- [ ] as a user, I can now set the SHOW_SERVICE_PAGE variable to true if I want my app to show a page for each service
- [ ] as a user, the service page is hidden by default. 

## related

webstore PR: https://github.com/scientist-softserv/webstore/pull/145

ticket: https://github.com/scientist-softserv/webstore/issues/131