### PR TITLE
136 refactor error

### DIFF
--- a/src/components/Error/Error.jsx
+++ b/src/components/Error/Error.jsx
@@ -3,26 +3,31 @@ import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import { Alert, Button, Container } from 'react-bootstrap'
 
-const Error = ({ errors, showBackButton, canDismissAlert, router }) => {
-  const { errorTitle, errorText, variant } = errors
+const Error = ({ alert, buttonProps, dismissible, withBackButton }) => {
   const [show, setShow] = useState(true)
+  const { title, body, variant } = alert
+  let onClick, text
+  if (withBackButton) ({ onClick, text } = buttonProps)
 
   return (
     show && (
       <Container>
-        <Alert className='my-5 text-break' variant={variant} onClose={() => setShow(false)} dismissible={canDismissAlert}>
-          {errorTitle && (
-            <Alert.Heading>{errorTitle}</Alert.Heading>
+        <Alert className='my-5 text-break' variant={variant} onClose={() => setShow(false)} dismissible={dismissible}>
+          {title && (
+            <Alert.Heading>{title}</Alert.Heading>
           )}
-          {errorText.map((errorMessage, index) => (
-            <p key={index}>{errorMessage}</p>
+          {body.map((text, index) => (
+            <p className='mb-0' key={index}>{text}</p>
           ))}
-          {showBackButton && (
+          {withBackButton && (
             <>
               <hr />
               <div className='d-flex justify-content-end'>
-                <Button onClick={() => router.back()} variant={`outline-${variant}`}>
+                {/* <Button onClick={() => router.back()} variant={`outline-${variant}`}>
                   Click to return to the previous page.
+                </Button> */}
+                <Button onClick={onClick} variant={`outline-${variant}`}>
+                  {text}
                 </Button>
               </div>
             </>
@@ -34,19 +39,25 @@ const Error = ({ errors, showBackButton, canDismissAlert, router }) => {
 }
 
 Error.propTypes = {
-  canDismissAlert: PropTypes.bool,
-  errors: PropTypes.shape({
-    errorText: PropTypes.arrayOf(PropTypes.string).isRequired,
-    errorTitle: PropTypes.string,
+  alert: PropTypes.shape({
+    body: PropTypes.arrayOf(PropTypes.string).isRequired,
+    title: PropTypes.string,
     variant: PropTypes.string.isRequired,
   }).isRequired,
-  showBackButton: PropTypes.bool,
-  router: PropTypes.shape({}).isRequired,
+  buttonProps: PropTypes.shape({
+    onClick: PropTypes.func,
+    text: PropTypes.string,
+  }),
+  dismissible: PropTypes.bool,
+  withBackButton: PropTypes.bool,
 }
 
 Error.defaultProps = {
-  canDismissAlert: false,
-  showBackButton: true,
+  buttonProps: {
+    text: 'Click to return to the previous page.'
+  },
+  dismissible: true,
+  withBackButton: false,
 }
 
 export default Error

--- a/src/components/Error/Error.stories.jsx
+++ b/src/components/Error/Error.stories.jsx
@@ -10,20 +10,41 @@ const Template = (args) => <Error {...args} />
 
 export const Default = Template.bind({})
 Default.args = {
-  errors: {
-    errorTitle: 'Errors:',
-    errorText: ['this is an error in dev. error block would go here', 'this is a second error message', 'this is a third error message'],
-    variant: 'danger'
-  }
+  alert: {
+    title: '',
+    body: ['A standard alert.'],
+    variant: 'warning'
+  },
+  buttonProps: {
+    text: 'Click to return to the previous page.'
+  },
+  dismissible: true,
+  withBackButton: false,
 }
 
-export const Alternate = Template.bind({})
-Alternate.args = {
-  canDismissAlert: true,
-  errors: {
-    errorTitle: "We're sorry, something went wrong.",
-    errorText: ['Please refresh the page and try again. this is an error in prod'],
-    variant: 'danger'
+export const WithError = Template.bind({})
+WithError.args = {
+  alert: {
+    title: "We're sorry, something went wrong.",
+    body: ['This is how an error would present in dev. There are instances where there may be several api errors on a single page. We would render them all.', 'This is a second error message.', 'This is a third error message.'],
+    variant: 'warning'
   },
-  showBackButton: false,
+  buttonProps: {
+    onClick: () => console.log('click me!'),
+    text: 'Click to return to the previous page.'
+  },
+  dismissible: false,
+  withBackButton: true,
+}
+
+export const UnauthorizedUser = Template.bind({})
+UnauthorizedUser.args = {
+  alert: {
+    title: 'Unauthorized',
+    body: ['Please sign in to access this page.'],
+    variant: 'info'
+  },
+  buttonProps: {},
+  dismissible: false,
+  withBackButton: false,
 }

--- a/src/components/Notice/Notice.jsx
+++ b/src/components/Notice/Notice.jsx
@@ -23,9 +23,6 @@ const Notice = ({ alert, buttonProps, dismissible, withBackButton }) => {
             <>
               <hr />
               <div className='d-flex justify-content-end'>
-                {/* <Button onClick={() => router.back()} variant={`outline-${variant}`}>
-                  Click to return to the previous page.
-                </Button> */}
                 <Button onClick={onClick} variant={`outline-${variant}`}>
                   {text}
                 </Button>

--- a/src/components/Notice/Notice.jsx
+++ b/src/components/Notice/Notice.jsx
@@ -16,9 +16,29 @@ const Notice = ({ alert, buttonProps, dismissible, withBackButton }) => {
           {title && (
             <Alert.Heading>{title}</Alert.Heading>
           )}
-          {body.map((text, index) => (
-            <p className='mb-0' key={index}>{text}</p>
-          ))}
+          {body.map((text, index) => {
+            // If "text" is a JSON string, return it as a formatted code block
+            // Otherwise, return it as a regular string
+            const isJSONParsable = () => {
+              try {
+                JSON.parse(text)
+                return true
+              } catch (error) {
+                return false
+              }
+            }
+            const isJavascriptObject = isJSONParsable(text)
+
+            return (
+              <>
+                {isJavascriptObject ? (
+                  <pre className='mb-0' key={index}>{text}</pre>
+                ) : (
+                  <p className='mb-0' key={index}>{text}</p>
+                )}
+              </>
+            )
+          })}
           {withBackButton && (
             <>
               <hr />

--- a/src/components/Notice/Notice.jsx
+++ b/src/components/Notice/Notice.jsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import { Alert, Button, Container } from 'react-bootstrap'
 
-const Error = ({ alert, buttonProps, dismissible, withBackButton }) => {
+const Notice = ({ alert, buttonProps, dismissible, withBackButton }) => {
   const [show, setShow] = useState(true)
   const { title, body, variant } = alert
   let onClick, text
@@ -38,7 +38,7 @@ const Error = ({ alert, buttonProps, dismissible, withBackButton }) => {
   )
 }
 
-Error.propTypes = {
+Notice.propTypes = {
   alert: PropTypes.shape({
     body: PropTypes.arrayOf(PropTypes.string).isRequired,
     title: PropTypes.string,
@@ -52,7 +52,7 @@ Error.propTypes = {
   withBackButton: PropTypes.bool,
 }
 
-Error.defaultProps = {
+Notice.defaultProps = {
   buttonProps: {
     text: 'Click to return to the previous page.'
   },
@@ -60,4 +60,4 @@ Error.defaultProps = {
   withBackButton: false,
 }
 
-export default Error
+export default Notice

--- a/src/components/Notice/Notice.jsx
+++ b/src/components/Notice/Notice.jsx
@@ -6,7 +6,8 @@ import { Alert, Button, Container } from 'react-bootstrap'
 const Notice = ({ alert, buttonProps, dismissible, withBackButton }) => {
   const [show, setShow] = useState(true)
   const { title, body, variant } = alert
-  let onClick, text
+  let onClick
+  let text
   if (withBackButton) ({ onClick, text } = buttonProps)
 
   return (
@@ -16,27 +17,25 @@ const Notice = ({ alert, buttonProps, dismissible, withBackButton }) => {
           {title && (
             <Alert.Heading>{title}</Alert.Heading>
           )}
-          {body.map((text, index) => {
-            // If "text" is a JSON string, return it as a formatted code block
+          {body.map((message, index) => {
+            // If "message" is a JSON string, return it as a formatted code block
             // Otherwise, return it as a regular string
             const isJSONParsable = () => {
               try {
-                JSON.parse(text)
+                JSON.parse(message)
                 return true
               } catch (error) {
                 return false
               }
             }
-            const isJavascriptObject = isJSONParsable(text)
+            const isJavascriptObject = isJSONParsable(message)
 
             return (
-              <>
-                {isJavascriptObject ? (
-                  <pre className='mb-0' key={index}>{text}</pre>
-                ) : (
-                  <p className='mb-0' key={index}>{text}</p>
-                )}
-              </>
+              isJavascriptObject ? (
+                <pre className='mb-0' key={index}>{message}</pre>
+              ) : (
+                <p className='mb-0' key={index}>{message}</p>
+              )
             )
           })}
           {withBackButton && (

--- a/src/components/Notice/Notice.jsx
+++ b/src/components/Notice/Notice.jsx
@@ -50,9 +50,7 @@ Notice.propTypes = {
 }
 
 Notice.defaultProps = {
-  buttonProps: {
-    text: 'Click to return to the previous page.'
-  },
+  buttonProps: {},
   dismissible: true,
   withBackButton: false,
 }

--- a/src/components/Notice/Notice.stories.jsx
+++ b/src/components/Notice/Notice.stories.jsx
@@ -13,7 +13,7 @@ Default.args = {
   alert: {
     title: '',
     body: ['A standard alert.'],
-    variant: 'warning'
+    variant: 'warning',
   },
   buttonProps: {},
   dismissible: true,
@@ -26,7 +26,7 @@ Error.args = {
     title: "We're sorry, something went wrong.",
     body: [
       JSON.stringify({
-        message: 'This is how an error would present in dev. There are instances where there may be several api errors on a single page. We would render them all.',
+        message: 'There are instances where there may be several api errors on a single page. We would render them all.',
         name: 'First',
         status: 422,
       }, null, 2),
@@ -41,11 +41,11 @@ Error.args = {
         status: 422,
       }, null, 2),
     ],
-    variant: 'warning'
+    variant: 'warning',
   },
   buttonProps: {
     onClick: () => console.log('click me!'),
-    text: 'Click to return to the previous page.'
+    text: 'Click to return to the previous page.',
   },
   dismissible: false,
   withBackButton: true,
@@ -56,7 +56,7 @@ UnauthorizedUser.args = {
   alert: {
     title: 'Unauthorized',
     body: ['Please sign in to access this page.'],
-    variant: 'info'
+    variant: 'info',
   },
   buttonProps: {},
   dismissible: false,

--- a/src/components/Notice/Notice.stories.jsx
+++ b/src/components/Notice/Notice.stories.jsx
@@ -1,12 +1,12 @@
 import React from 'react'
-import Error from './Error'
+import Notice from './Notice'
 
 export default {
-  title: 'Components/Error',
-  component: Error,
+  title: 'Components/Notice',
+  component: Notice,
 }
 
-const Template = (args) => <Error {...args} />
+const Template = (args) => <Notice {...args} />
 
 export const Default = Template.bind({})
 Default.args = {
@@ -22,8 +22,8 @@ Default.args = {
   withBackButton: false,
 }
 
-export const WithError = Template.bind({})
-WithError.args = {
+export const Error = Template.bind({})
+Error.args = {
   alert: {
     title: "We're sorry, something went wrong.",
     body: ['This is how an error would present in dev. There are instances where there may be several api errors on a single page. We would render them all.', 'This is a second error message.', 'This is a third error message.'],

--- a/src/components/Notice/Notice.stories.jsx
+++ b/src/components/Notice/Notice.stories.jsx
@@ -15,9 +15,7 @@ Default.args = {
     body: ['A standard alert.'],
     variant: 'warning'
   },
-  buttonProps: {
-    text: 'Click to return to the previous page.'
-  },
+  buttonProps: {},
   dismissible: true,
   withBackButton: false,
 }

--- a/src/components/Notice/Notice.stories.jsx
+++ b/src/components/Notice/Notice.stories.jsx
@@ -24,7 +24,23 @@ export const Error = Template.bind({})
 Error.args = {
   alert: {
     title: "We're sorry, something went wrong.",
-    body: ['This is how an error would present in dev. There are instances where there may be several api errors on a single page. We would render them all.', 'This is a second error message.', 'This is a third error message.'],
+    body: [
+      JSON.stringify({
+        message: 'This is how an error would present in dev. There are instances where there may be several api errors on a single page. We would render them all.',
+        name: 'First',
+        status: 422,
+      }, null, 2),
+      JSON.stringify({
+        message: 'This is a second error message.',
+        name: 'Second',
+        status: 422,
+      }, null, 2),
+      JSON.stringify({
+        message: 'This is a third error message.',
+        name: 'Third',
+        status: 422,
+      }, null, 2),
+    ],
     variant: 'warning'
   },
   buttonProps: {

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -7,10 +7,10 @@ import AdditionalInfo from './AdditionalInfo/AdditionalInfo'
 import BlankRequestForm from './BlankRequestForm/BlankRequestForm'
 import Button from './Button/Button'
 import CollapsibleSection from './CollapsibleSection/CollapsibleSection'
-import Error from './Error/Error'
 import Image from './Image/Image'
 import Link from './Link/Link'
 import Loading from './Loading/Loading'
+import Notice from './Notice/Notice'
 import SearchBar from './SearchBar/SearchBar'
 import ShippingDetails from './ShippingDetails/ShippingDetails'
 import SocialIcon from './SocialIcon/SocialIcon'
@@ -23,10 +23,10 @@ export {
   BlankRequestForm,
   Button,
   CollapsibleSection,
-  Error,
   Image,
   Link,
   Loading,
+  Notice,
   SearchBar,
   ShippingDetails,
   SocialIcon,


### PR DESCRIPTION
# story
~since I renamed the file, it appears as an entirely new file. In order to see the actual changes (which there are still plenty of), look at [this commit](https://github.com/scientist-softserv/webstore-component-library/pull/137/commits/a1d9c5c9d80768ba7266e6277957008aa5bbcbe4). The second commit was simply updating all instances of `Error` to `Notice`~

We needed to use alerts for reasons other than errors so a refactor on the Error component was done so it was more flexible. 

# Expected behavior
- can display formatted error messages
- can display regular text alerts

# Demo
<details>
<summary>Default</summary>

![image](https://user-images.githubusercontent.com/29032869/214977210-411bab50-b26c-4fd2-b7d2-bbd1551935fd.png)
</details>

<details>
<summary>Error</summary>

![image](https://user-images.githubusercontent.com/29032869/214977306-5f5a41bb-3ad4-46f8-99bd-cac82bb49ce7.png)
</details>

<details>
<summary>Unauthenticated user</summary>

![image](https://user-images.githubusercontent.com/29032869/214977339-ab84954b-34e1-4c46-84e1-8f81bdb2126f.png)
</details>