### PR TITLE
157- Account for 0 requests

### DIFF
--- a/src/compounds/RequestList/RequestList.jsx
+++ b/src/compounds/RequestList/RequestList.jsx
@@ -9,12 +9,13 @@ const RequestList = ({ requests }) => (
     <Title title='My Requests' size='medium' />
     <div className='rounded overflow-hidden'>
       {requests.length === 0 ? (
-          <p className='mt-2'>
-            You do not have any requests yet.
-            <br/>
-            <a href='/browse'>Browse our available services</a> to create a request, or start a new general request by clicking the <b>"Initiate a Request"</b> button above. 
-          </p>
-        ) : (requests.map((req, index) => (
+        <p className='mt-2'>
+          You do not have any requests yet.
+          <br />
+          <a href='/browse'>Browse our available services</a> to create a request,
+          or start a new general request by clicking the <b>"Initiate a Request"</b> button above.
+        </p>
+      ) : (requests.map((req, index) => (
         <Link key={req.id} href={`${req.href}`} passHref legacyBehavior>
           <RequestItem request={req} index={index} />
         </Link>

--- a/src/compounds/RequestList/RequestList.jsx
+++ b/src/compounds/RequestList/RequestList.jsx
@@ -8,11 +8,17 @@ const RequestList = ({ requests }) => (
   <>
     <Title title='My Requests' size='medium' />
     <div className='rounded overflow-hidden'>
-      {requests.map((req, index) => (
+      {requests.length === 0 ? (
+          <p className='mt-2'>
+            You do not have any requests yet.
+            <br/>
+            <a href='/browse'>Browse our available services</a> to create a request, or start a new general request by clicking the <b>"Initiate a Request"</b> button above. 
+          </p>
+        ) : (requests.map((req, index) => (
         <Link key={req.id} href={`${req.href}`} passHref legacyBehavior>
           <RequestItem request={req} index={index} />
         </Link>
-      ))}
+      )))}
     </div>
   </>
 )

--- a/src/compounds/RequestList/RequestList.stories.jsx
+++ b/src/compounds/RequestList/RequestList.stories.jsx
@@ -41,3 +41,8 @@ Default.args = {
     },
   ],
 }
+
+export const Alternate = Template.bind({})
+Alternate.args = {
+  requests: [],
+}


### PR DESCRIPTION
# summary
add backup text for when there are no requests in the request list.

# related 
Closes #157 

# screenshot
Alternate story: when requests is an empty array
<img width="764" alt="image" src="https://user-images.githubusercontent.com/73361970/218510759-87670e54-31cd-4bd8-84d2-a1207579a88b.png">


# acceptance
- [ ] as a user, I can see backup text if I have 0 requests in my request list