### PR TITLE
152 Add attachments

### DIFF
--- a/src/assets/fontawesome.js
+++ b/src/assets/fontawesome.js
@@ -2,6 +2,7 @@ import { library } from '@fortawesome/fontawesome-svg-core'
 import {
   faArrowDown,
   faArrowUp,
+  faDownload,
   faEnvelope,
   faFileLines,
   faListCheck,
@@ -19,6 +20,7 @@ import {
 library.add(
   faArrowDown,
   faArrowUp,
+  faDownload,
   faEnvelope,
   faFileLines,
   faListCheck,

--- a/src/components/FilesTable/FilesTable.jsx
+++ b/src/components/FilesTable/FilesTable.jsx
@@ -1,9 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import {
-  // Button,
-  Table,
-} from 'react-bootstrap'
+import { Table } from 'react-bootstrap'
+import Link from '../Link/Link'
 import { allowNull } from '../../resources/utilityFunctions'
 
 const FilesTable = ({ addClass, files }) => {
@@ -21,17 +19,24 @@ const FilesTable = ({ addClass, files }) => {
           <th>Uploaded By</th>
           <th>Size</th>
           <th>Created At</th>
+          <th></th>
         </tr>
       </thead>
       <tbody>
         {files.map((file) => {
-          const { uuid, fileName, uploadedBy, contentLength, createdAt } = file
+          const { contentLength, createdAt, fileName, href, uploadedBy, uuid  } = file
           return (
             <tr key={uuid} className='small'>
               <td>{fileName}</td>
               <td>{uploadedBy}</td>
               <td>{contentLength}</td>
               <td>{createdAt}</td>
+              <td>
+                <Link
+                  icon='fa-download'
+                  href={href}
+                />
+              </td>
             </tr>
           )
         })}

--- a/src/components/FilesTable/FilesTable.jsx
+++ b/src/components/FilesTable/FilesTable.jsx
@@ -31,7 +31,7 @@ const FilesTable = ({ addClass, files }) => {
               <td>{uploadedBy}</td>
               <td>{contentLength}</td>
               <td>{createdAt}</td>
-              <td>
+              <td className='text-center'>
                 <Link
                   icon='fa-download'
                   href={href}

--- a/src/components/FilesTable/FilesTable.jsx
+++ b/src/components/FilesTable/FilesTable.jsx
@@ -19,12 +19,12 @@ const FilesTable = ({ addClass, files }) => {
           <th>Uploaded By</th>
           <th>Size</th>
           <th>Created At</th>
-          <th></th>
+          <th aria-label='actions' />
         </tr>
       </thead>
       <tbody>
         {files.map((file) => {
-          const { contentLength, createdAt, fileName, href, uploadedBy, uuid  } = file
+          const { contentLength, createdAt, fileName, href, uploadedBy, uuid } = file
           return (
             <tr key={uuid} className='small'>
               <td>{fileName}</td>
@@ -35,6 +35,7 @@ const FilesTable = ({ addClass, files }) => {
                 <Link
                   icon='fa-download'
                   href={href}
+                  aria-label='download'
                 />
               </td>
             </tr>

--- a/src/components/Link/Link.jsx
+++ b/src/components/Link/Link.jsx
@@ -21,13 +21,14 @@ Link.propTypes = {
   addClass: PropTypes.string,
   href: PropTypes.string.isRequired,
   icon: PropTypes.string,
-  label: PropTypes.string.isRequired,
+  label: PropTypes.string,
   style: PropTypes.shape({}),
 }
 
 Link.defaultProps = {
   addClass: '',
   icon: '',
+  label: '',
   style: {},
 }
 

--- a/src/components/Link/Link.jsx
+++ b/src/components/Link/Link.jsx
@@ -11,7 +11,7 @@ const Link = ({ addClass, href, icon, label, style, ...props }) => (
     {...props}
   >
     {icon && (
-      <FontAwesomeIcon icon={icon} className='me-2 small' />
+      <FontAwesomeIcon icon={icon} className={`small ${label.length > 0 && 'me-2'}`} />
     )}
     {label}
   </a>

--- a/src/compounds/ActionsGroup/ActionsGroup.jsx
+++ b/src/compounds/ActionsGroup/ActionsGroup.jsx
@@ -7,7 +7,7 @@ import ViewFiles from './actions/ViewFiles'
 import { allowNull } from '../../resources/utilityFunctions'
 import './actions-group.scss'
 
-const ActionsGroup = ({ backgroundColor, handleSendingMessagesOrFiles, initialFiles }) => {
+const ActionsGroup = ({ backgroundColor, handleSendingMessagesOrFiles, files }) => {
   const [show, setShow] = useState(false)
   const [action, setAction] = useState(null)
 
@@ -55,7 +55,7 @@ const ActionsGroup = ({ backgroundColor, handleSendingMessagesOrFiles, initialFi
           <ViewFiles
             backgroundColor={backgroundColor}
             handleClose={handleClose}
-            initialFiles={initialFiles}
+            files={files}
             onSubmit={handleSendingMessagesOrFiles}
           />
         )}
@@ -66,7 +66,7 @@ const ActionsGroup = ({ backgroundColor, handleSendingMessagesOrFiles, initialFi
 ActionsGroup.propTypes = {
   backgroundColor: PropTypes.string,
   handleSendingMessagesOrFiles: PropTypes.func.isRequired,
-  initialFiles: PropTypes.arrayOf(
+  files: PropTypes.arrayOf(
     PropTypes.shape({
       contentLength: PropTypes.string.isRequired,
       contentType: PropTypes.string.isRequired,

--- a/src/compounds/ActionsGroup/actions/ViewFiles.jsx
+++ b/src/compounds/ActionsGroup/actions/ViewFiles.jsx
@@ -49,11 +49,11 @@ const ViewFiles = ({ backgroundColor, files, handleClose, onSubmit }) => {
       throw new Error(error)
     }
   }
-  
+
   const handleSubmit = async (event) => {
     event.preventDefault()
     await onSubmit({ files: apiV2CompatibleStrings([...tempFiles]) })
-    if (tempFiles.length > 0) { 
+    if (tempFiles.length > 0) {
       setShowSuccessAlert(true)
       setTempFiles([])
     }
@@ -74,15 +74,15 @@ const ViewFiles = ({ backgroundColor, files, handleClose, onSubmit }) => {
           <h6 className='mt-3'>Upload Additional Documents</h6>
           <InputGroup controlId='attachments' className='mb-3'>
             <Form.Control
-            multiple
-            type='file'
-            onChange={handleAddFile}
-            ref={fileRef}
+              multiple
+              type='file'
+              onChange={handleAddFile}
+              ref={fileRef}
             />
             <Button
-            variant='outline-primary'
-            onClick={handleSubmit}
-            type='submit'
+              variant='outline-primary'
+              onClick={handleSubmit}
+              type='submit'
             >
               <FontAwesomeIcon icon='fa-upload' />
             </Button>
@@ -93,16 +93,17 @@ const ViewFiles = ({ backgroundColor, files, handleClose, onSubmit }) => {
             const fileName = Object.keys(file)[0]
             return (
               <ListGroup.Item key={fileName} className='d-flex align-items-center'>
-              <span>{fileName}</span>
-              <CloseButton onClick={() => handleDeleteTempFile(file)} className='ms-auto' />
+                <span>{fileName}</span>
+                <CloseButton onClick={() => handleDeleteTempFile(file)} className='ms-auto' />
               </ListGroup.Item>
             )
           })}
-          {showSuccessAlert && 
-            <Alert variant='success' onClose={() => setShowSuccessAlert(false)} dismissible >
-              Your files have been uploaded successfully. It may take some time for them to appear below. 
-            </Alert>
-          }
+          {showSuccessAlert
+            && (
+              <Alert variant='success' onClose={() => setShowSuccessAlert(false)} dismissible>
+                Your files have been uploaded successfully. It may take some time for them to appear below.
+              </Alert>
+            )}
         </ListGroup>
         <Tabs defaultActiveKey='files' id='document-tabs' justify fill>
           {documentTabs && documentTabs.map((tab) => {
@@ -145,10 +146,11 @@ ViewFiles.propTypes = {
     }),
   ).isRequired,
   handleClose: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
 }
 
 ViewFiles.defaultProps = {
-  backgroundColor: 'secondary'
+  backgroundColor: 'secondary',
 }
 
 export default ViewFiles

--- a/src/compounds/ActionsGroup/actions/ViewFiles.jsx
+++ b/src/compounds/ActionsGroup/actions/ViewFiles.jsx
@@ -15,12 +15,10 @@ import {
 import FilesTable from '../../../components/FilesTable/FilesTable'
 import { allowNull, apiV2CompatibleStrings, convertToBase64 } from '../../../resources/utilityFunctions'
 
-const ViewFiles = ({ backgroundColor, initialFiles, handleClose, onSubmit }) => {
+const ViewFiles = ({ backgroundColor, files, handleClose, onSubmit }) => {
   const fileRef = useRef(null)
-  const [files, setFiles] = useState(initialFiles)
   const [tempFiles, setTempFiles] = useState([])
   const [showSuccessAlert, setShowSuccessAlert] = useState(false)
-  //let newlyAddedFiles = []
   const documentTabs = [
     {
       eventKey: 'files',
@@ -34,10 +32,6 @@ const ViewFiles = ({ backgroundColor, initialFiles, handleClose, onSubmit }) => 
     },
   ]
 
-    // TODO(summercook):
-  // - comment back in the following 3 methods once posting messages/attachments is working
-  // may need to use the handleSendingMessagesOrFiles to post
-  
   const handleAddFile = async (event) => {
     event.preventDefault()
     try {
@@ -113,7 +107,7 @@ const ViewFiles = ({ backgroundColor, initialFiles, handleClose, onSubmit }) => 
         <Tabs defaultActiveKey='files' id='document-tabs' justify fill>
           {documentTabs && documentTabs.map((tab) => {
             const { eventKey, title, status } = tab
-            const filteredFiles = initialFiles.filter((f) => (status === f.status) || (status === 'Other File' && f.status === null))
+            const filteredFiles = files.filter((f) => (status === f.status) || (status === 'Other File' && f.status === null))
             return (
               <Tab
                 eventKey={eventKey}
@@ -137,7 +131,7 @@ const ViewFiles = ({ backgroundColor, initialFiles, handleClose, onSubmit }) => 
 
 ViewFiles.propTypes = {
   backgroundColor: PropTypes.string,
-  initialFiles: PropTypes.arrayOf(
+  files: PropTypes.arrayOf(
     PropTypes.shape({
       contentLength: PropTypes.string.isRequired,
       contentType: PropTypes.string.isRequired,

--- a/src/compounds/ActionsGroup/actions/ViewFiles.jsx
+++ b/src/compounds/ActionsGroup/actions/ViewFiles.jsx
@@ -1,15 +1,23 @@
-import React
-  from 'react'
+import React, { useState, useRef } from 'react'
 import PropTypes from 'prop-types'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import {
+  Button,
+  CloseButton,
+  Form,
+  InputGroup,
+  ListGroup,
   Offcanvas,
   Tab,
   Tabs,
 } from 'react-bootstrap'
 import FilesTable from '../../../components/FilesTable/FilesTable'
-import { allowNull } from '../../../resources/utilityFunctions'
+import { allowNull, apiV2CompatibleStrings, convertToBase64 } from '../../../resources/utilityFunctions'
 
-const ViewFiles = ({ backgroundColor, initialFiles, handleClose }) => {
+const ViewFiles = ({ backgroundColor, initialFiles, handleClose, onSubmit }) => {
+  const fileRef = useRef(null)
+  const [files, setFiles] = useState(initialFiles)
+  const [tempFiles, setTempFiles] = useState([])
   const documentTabs = [
     {
       eventKey: 'files',
@@ -23,16 +31,78 @@ const ViewFiles = ({ backgroundColor, initialFiles, handleClose }) => {
     },
   ]
 
+    // TODO(summercook):
+  // - comment back in the following 3 methods once posting messages/attachments is working
+  // may need to use the handleSendingMessagesOrFiles to post
+  
+  const handleAddFile = async (event) => {
+    event.preventDefault()
+    try {
+      // "event.target.files" returns a FileList, which looks like an array but does not respond to array methods
+      // except "length". we are using the spread syntax to set "files" to be an iterable array
+      const fileArray = [...event.target.files]
+      const newBase64Files = await Promise.all(convertToBase64(fileArray))
+      const newFiles = fileArray.map((file, index) => ({ [file.name]: newBase64Files[index] }))
+      setTempFiles([...tempFiles, ...newFiles])
+      console.log(tempFiles, 'tempFilesAfterAdd')
+      fileRef.current.value = ''
+    } catch (error) {
+      throw new Error(error)
+    }
+  }
+  
+  const handleSubmit = (event) => {
+    event.preventDefault()
+    onSubmit({ files: apiV2CompatibleStrings([...tempFiles]) })
+    console.log(files, 'filesBeforeSubmit')
+    //setFiles([...files, ...apiCompatibleTempFiles])
+    setTempFiles([])
+  }
+
+  const handleDeleteTempFile = (file) => {
+    const remainingFiles = tempFiles.filter((obj) => obj !== file)
+    setTempFiles(remainingFiles)
+  }
+
   return (
     <Offcanvas show onHide={handleClose} placement='end' scroll='true'>
       <Offcanvas.Header className={`d-flex border-bottom px-3 py-2 bg-${backgroundColor}-8`} closeButton>
         <Offcanvas.Title>Documents</Offcanvas.Title>
       </Offcanvas.Header>
       <Offcanvas.Body className='border rounded p-2 m-3'>
+        <Form>
+          <h6 className='mt-3'>Upload Additional Documents</h6>
+          <InputGroup controlId='attachments' className='mb-3'>
+            <Form.Control
+            multiple
+            type='file'
+            onChange={handleAddFile}
+            ref={fileRef}
+            />
+            <Button
+            variant='outline-primary'
+            onClick={handleSubmit}
+            type='submit'
+            >
+              <FontAwesomeIcon icon='fa-upload' />
+            </Button>
+          </InputGroup>
+        </Form>
+        <ListGroup variant='flush'>
+          {tempFiles.map((file) => {
+            const fileName = Object.keys(file)[0]
+            return (
+              <ListGroup.Item key={fileName} className='d-flex align-items-center'>
+              <span>{fileName}</span>
+              <CloseButton onClick={() => handleDeleteTempFile(file)} className='ms-auto' />
+              </ListGroup.Item>
+            )
+          })}
+        </ListGroup>
         <Tabs defaultActiveKey='files' id='document-tabs' justify fill>
           {documentTabs && documentTabs.map((tab) => {
             const { eventKey, title, status } = tab
-            const filteredFiles = initialFiles.filter((f) => (status === f.status) || (status === 'Other File' && f.status === null))
+            const filteredFiles = files.filter((f) => (status === f.status) || (status === 'Other File' && f.status === null))
             return (
               <Tab
                 eventKey={eventKey}
@@ -43,6 +113,7 @@ const ViewFiles = ({ backgroundColor, initialFiles, handleClose }) => {
                 <FilesTable
                   files={filteredFiles}
                   status={status}
+                  handleDeleteFile={handleDeleteTempFile}
                 />
               </Tab>
             )


### PR DESCRIPTION
# Story
- a user can now add attachments from the request page "view files" action
- they can also download these attachments

# Previous behavior
- users could not add additional attachments after creating a request except through sending messages

# Expected behavior after this PR
- [ ] User can add attachments from View Files pane
- [ ] User will see an alert when their attachments are uploaded successfully
- [ ] the alert should go away automatically if the user tries to add more attachments
- [ ] new attachments will appear in the View Files pane before page refresh

# Video/screenshots
<img width="500" alt="image" src="https://user-images.githubusercontent.com/73361970/220383306-a4317e30-39e5-4c70-9856-41d17504f9db.png">

<img width="500" alt="image" src="https://user-images.githubusercontent.com/73361970/220383382-0944b8cf-fffa-4114-a69a-2024abe4e4a1.png">

<img width="500" alt="image" src="https://user-images.githubusercontent.com/73361970/220383514-9762f36e-bbb1-49d7-8b3d-d5c3885fec8a.png">

https://share.getcloudapp.com/v1uP5dz7

# Related
#152 
Webstore PR: https://github.com/scientist-softserv/webstore/pull/222