### PR TITLE
137 accept sow

### DIFF
--- a/src/components/Notice/Notice.jsx
+++ b/src/components/Notice/Notice.jsx
@@ -3,17 +3,22 @@ import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import { Alert, Button, Container } from 'react-bootstrap'
 
-const Notice = ({ alert, buttonProps, dismissible, withBackButton }) => {
+const Notice = ({ addClass, alert, buttonProps, dismissible, withBackButton }) => {
   const [show, setShow] = useState(true)
-  const { title, body, variant } = alert
+  const { title, body, variant, onClose } = alert
   let onClick
   let text
   if (withBackButton) ({ onClick, text } = buttonProps)
 
   return (
     show && (
-      <Container>
-        <Alert className='my-5 text-break' variant={variant} onClose={() => setShow(false)} dismissible={dismissible}>
+      <Container className={addClass}>
+        <Alert
+          className='text-break'
+          variant={variant}
+          onClose={onClose || (() => setShow(false))}
+          dismissible={dismissible}
+        >
           {title && (
             <Alert.Heading>{title}</Alert.Heading>
           )}
@@ -55,8 +60,10 @@ const Notice = ({ alert, buttonProps, dismissible, withBackButton }) => {
 }
 
 Notice.propTypes = {
+  addClass: PropTypes.string,
   alert: PropTypes.shape({
     body: PropTypes.arrayOf(PropTypes.string).isRequired,
+    onClose: PropTypes.func,
     title: PropTypes.string,
     variant: PropTypes.string.isRequired,
   }).isRequired,
@@ -69,6 +76,10 @@ Notice.propTypes = {
 }
 
 Notice.defaultProps = {
+  addClass: '',
+  alert: {
+    onClose: () => {}
+  },
   buttonProps: {},
   dismissible: true,
   withBackButton: false,

--- a/src/components/Notice/Notice.jsx
+++ b/src/components/Notice/Notice.jsx
@@ -77,9 +77,6 @@ Notice.propTypes = {
 
 Notice.defaultProps = {
   addClass: '',
-  alert: {
-    onClose: () => {}
-  },
   buttonProps: {},
   dismissible: true,
   withBackButton: false,

--- a/src/compounds/Document/Document.jsx
+++ b/src/compounds/Document/Document.jsx
@@ -50,7 +50,7 @@ const Document = ({ acceptSOW, addClass, backgroundColor, document }) => {
                     <Dropdown.Item
                       href='#/action-1'
                       onClick={() => {
-                        acceptSOW
+                        onClick('Accept SOW')
                         setShowNotice(true)
                       }}
                     >

--- a/src/compounds/Document/Document.jsx
+++ b/src/compounds/Document/Document.jsx
@@ -6,7 +6,7 @@ import Notice from '../../components/Notice/Notice'
 import { allowNull } from '../../resources/utilityFunctions'
 import './document.scss'
 
-const Document = ({ document, addClass }) => {
+const Document = ({ acceptSOW, addClass, backgroundColor, document }) => {
   const {
     adPO, date, documentStatusColor, documentType, documentTypeColor, documentStatus, identifier, lineItems, poNumber,
     relatedSOWIdentifier, requestIdentifier, shippingPrice, shipTo, shipFrom, subtotalPrice, taxAmount, terms, totalPrice,
@@ -67,7 +67,7 @@ const Document = ({ document, addClass }) => {
               <Notice
                 addClass='my-3'
                 alert={{
-                  body: [alertBody],
+                  body: [`SOW ${identifier} has been accepted successfully. Now awaiting purchase order.`],
                   variant: 'success',
                   onClose: () => setShowNotice(false),
                 }}
@@ -118,7 +118,6 @@ const Document = ({ document, addClass }) => {
 
 Document.propTypes = {
   addClass: PropTypes.string,
-  alertBody: PropTypes.string,
   backgroundColor: PropTypes.string,
   acceptSOW: PropTypes.func.isRequired,
   document: PropTypes.shape({

--- a/src/compounds/Document/Document.jsx
+++ b/src/compounds/Document/Document.jsx
@@ -4,7 +4,7 @@ import { Dropdown, Offcanvas } from 'react-bootstrap'
 import LineItemsTable from '../../components/LineItemsTable/LineItemsTable'
 import './document.scss'
 
-const Document = ({ document, addClass }) => {
+const Document = ({ accessToken, addClass, acceptSOW, document, request }) => {
   const { identifier, date, documentStatusColor, documentType,
     documentTypeColor, documentStatus, lineItems, requestIdentifier,
     shippingPrice, shipTo, shipFrom, subtotalPrice,
@@ -42,9 +42,13 @@ const Document = ({ document, addClass }) => {
                 Next Actions
               </Dropdown.Toggle>
               <Dropdown.Menu>
-                {/* TODO: @summer-cook Update this menu item so it submits this document for approval &
-                add more dropdown items depending on what actions we need here. */}
-                <Dropdown.Item href='#/action-1'>Submit for Approval</Dropdown.Item>
+                {/* TODO: @summer-cook SOW should have submit for approval. It should also ONLY show the submit for approval when the SOW has not yet been submitted. Need to figure out a way to tell if it has been submitted or not. . */}
+                <Dropdown.Item
+                  href='#/action-1'
+                  onClick={() => {acceptSOW({data: request, sowID: identifier, accessToken: accessToken})}}
+                >
+                  Submit for Approval
+                </Dropdown.Item>
               </Dropdown.Menu>
             </Dropdown>
           </div>
@@ -90,6 +94,8 @@ const Document = ({ document, addClass }) => {
 
 Document.propTypes = {
   addClass: PropTypes.string,
+  accessToken: PropTypes.string.isRequired,
+  acceptSOW: PropTypes.func.isRequired,
   document: PropTypes.shape({
     identifier: PropTypes.string.isRequired,
     date: PropTypes.string.isRequired,

--- a/src/compounds/Document/Document.jsx
+++ b/src/compounds/Document/Document.jsx
@@ -50,7 +50,7 @@ const Document = ({ acceptSOW, addClass, backgroundColor, document }) => {
                     <Dropdown.Item
                       href='#/action-1'
                       onClick={() => {
-                        onClick('Accept SOW')
+                        acceptSOW
                         setShowNotice(true)
                       }}
                     >

--- a/src/compounds/Document/Document.jsx
+++ b/src/compounds/Document/Document.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import { Dropdown, Offcanvas, Row } from 'react-bootstrap'
 import LineItemsTable from '../../components/LineItemsTable/LineItemsTable'
 import Notice from '../../components/Notice/Notice'
+import { allowNull } from '../../resources/utilityFunctions'
 import './document.scss'
 
 const Document = ({ accessToken, addClass, acceptSOW, backgroundColor, document, request }) => {
@@ -30,7 +31,7 @@ const Document = ({ accessToken, addClass, acceptSOW, backgroundColor, document,
           </small>
         </div>
         <div className='ms-auto p-2'>
-          <div className='badge p-2' style={{backgroundColor: documentStatusColor}}>
+          <div className='badge p-2' style={{ backgroundColor: documentStatusColor }}>
             {documentStatus}
           </div>
         </div>
@@ -38,45 +39,46 @@ const Document = ({ accessToken, addClass, acceptSOW, backgroundColor, document,
       <Offcanvas show={show} onHide={handleClose} placement='end' scroll='true'>
         <Offcanvas.Header className={`d-flex border-bottom px-3 py-2 bg-${backgroundColor}-8`} closeButton>
           <Offcanvas.Title> {documentType}: #{identifier}</Offcanvas.Title>
-          {documentType === 'SOW' &&
-            <div className='ms-auto me-2'>
-              <Dropdown>
-                <Dropdown.Toggle id='next-actions-dropdown' size='small' className='btn-outline-dark' variant={`btn-${backgroundColor}`}>
-                  Next Actions
-                </Dropdown.Toggle>
-                <Dropdown.Menu>
-                  {/* TODO: @summer-cook SOW should have submit for approval. It should also ONLY show the submit for approval when the SOW has not yet been submitted. Need to figure out a way to tell if it has been submitted or not. . */}
-                  <Dropdown.Item
-                    href='#/action-1'
-                    onClick={() => {
-                      acceptSOW({
-                        request: request,
-                        sowID: sowID,
-                        accessToken: accessToken,
-                      })
-                      setSowAccepted(true)
-                    }}
-                  >
-                    Submit for Approval
-                  </Dropdown.Item>
-                </Dropdown.Menu>
-              </Dropdown>
-            </div>
-          }
+          {documentType === 'SOW'
+            && (
+              <div className='ms-auto me-2'>
+                <Dropdown>
+                  <Dropdown.Toggle id='next-actions-dropdown' size='small' className='btn-outline-dark' variant={`btn-${backgroundColor}`}>
+                    Next Actions
+                  </Dropdown.Toggle>
+                  <Dropdown.Menu>
+                    <Dropdown.Item
+                      href='#/action-1'
+                      onClick={() => {
+                        acceptSOW({
+                          request,
+                          sowID,
+                          accessToken,
+                        })
+                        setSowAccepted(true)
+                      }}
+                    >
+                      Submit for Approval
+                    </Dropdown.Item>
+                  </Dropdown.Menu>
+                </Dropdown>
+              </div>
+            )}
         </Offcanvas.Header>
         <Offcanvas.Body>
-          {sowAccepted && 
-            <Row>
-              <Notice
-                addClass='my-3'
-                alert={{
-                  body: [`SOW ${identifier} has been accepted successfully. Now awaiting purchase order.`],
-                  variant: 'success',
-                  onClose: () => setSowAccepted(false)
-                }}
-              />
-            </Row>
-          }
+          {sowAccepted
+            && (
+              <Row>
+                <Notice
+                  addClass='my-3'
+                  alert={{
+                    body: [`SOW ${identifier} has been accepted successfully. Now awaiting purchase order.`],
+                    variant: 'success',
+                    onClose: () => setSowAccepted(false),
+                  }}
+                />
+              </Row>
+            )}
           <div className='d-block d-md-flex justify-content-between'>
             <div className='details'>
               <h6>Details:</h6>
@@ -138,11 +140,13 @@ Document.propTypes = {
       organizationName: PropTypes.string,
       text: PropTypes.string,
     }).isRequired,
+    sowID: allowNull(PropTypes.string),
     subtotalPrice: PropTypes.string.isRequired,
     taxAmount: PropTypes.string.isRequired,
     terms: PropTypes.string.isRequired,
     totalPrice: PropTypes.string.isRequired,
   }),
+  request: PropTypes.string.isRequired,
 }
 
 Document.defaultProps = {

--- a/src/compounds/Document/Document.jsx
+++ b/src/compounds/Document/Document.jsx
@@ -1,15 +1,17 @@
 import React, { useState } from 'react'
 import PropTypes from 'prop-types'
-import { Dropdown, Offcanvas } from 'react-bootstrap'
+import { Dropdown, Offcanvas, Row } from 'react-bootstrap'
 import LineItemsTable from '../../components/LineItemsTable/LineItemsTable'
+import Notice from '../../components/Notice/Notice'
 import './document.scss'
 
-const Document = ({ accessToken, addClass, acceptSOW, document, request }) => {
+const Document = ({ accessToken, addClass, acceptSOW, backgroundColor, document, request }) => {
   const { identifier, date, documentStatusColor, documentType,
     documentTypeColor, documentStatus, lineItems, requestIdentifier,
     shippingPrice, shipTo, shipFrom, sowID, subtotalPrice,
     taxAmount, terms, totalPrice } = document
   const [show, setShow] = useState(false)
+  const [sowAccepted, setSowAccepted] = useState(false)
   const handleClose = () => setShow(false)
   const handleShow = () => setShow(true)
 
@@ -34,30 +36,47 @@ const Document = ({ accessToken, addClass, acceptSOW, document, request }) => {
         </div>
       </div>
       <Offcanvas show={show} onHide={handleClose} placement='end' scroll='true'>
-        <Offcanvas.Header className='d-flex' closeButton>
+        <Offcanvas.Header className={`d-flex border-bottom px-3 py-2 bg-${backgroundColor}-8`} closeButton>
           <Offcanvas.Title> {documentType}: #{identifier}</Offcanvas.Title>
-          <div className='ms-auto me-2'>
-            <Dropdown>
-              <Dropdown.Toggle variant='light' id='dropdown-basic' size='small' className='border'>
-                Next Actions
-              </Dropdown.Toggle>
-              <Dropdown.Menu>
-                {/* TODO: @summer-cook SOW should have submit for approval. It should also ONLY show the submit for approval when the SOW has not yet been submitted. Need to figure out a way to tell if it has been submitted or not. . */}
-                <Dropdown.Item
-                  href='#/action-1'
-                  onClick={() => {acceptSOW({
-                    request: request,
-                    sowID: sowID,
-                    accessToken: accessToken,
-                  })}}
-                >
-                  Submit for Approval
-                </Dropdown.Item>
-              </Dropdown.Menu>
-            </Dropdown>
-          </div>
+          {documentType === 'SOW' &&
+            <div className='ms-auto me-2'>
+              <Dropdown>
+                <Dropdown.Toggle id='next-actions-dropdown' size='small' className='btn-outline-dark' variant={`btn-${backgroundColor}`}>
+                  Next Actions
+                </Dropdown.Toggle>
+                <Dropdown.Menu>
+                  {/* TODO: @summer-cook SOW should have submit for approval. It should also ONLY show the submit for approval when the SOW has not yet been submitted. Need to figure out a way to tell if it has been submitted or not. . */}
+                  <Dropdown.Item
+                    href='#/action-1'
+                    onClick={() => {
+                      acceptSOW({
+                        request: request,
+                        sowID: sowID,
+                        accessToken: accessToken,
+                      })
+                      setSowAccepted(true)
+                    }}
+                  >
+                    Submit for Approval
+                  </Dropdown.Item>
+                </Dropdown.Menu>
+              </Dropdown>
+            </div>
+          }
         </Offcanvas.Header>
         <Offcanvas.Body>
+          {sowAccepted && 
+            <Row>
+              <Notice
+                addClass='my-3'
+                alert={{
+                  body: [`SOW ${identifier} has been accepted successfully. Now awaiting purchase order.`],
+                  variant: 'success',
+                  onClose: () => setSowAccepted(false)
+                }}
+              />
+            </Row>
+          }
           <div className='d-block d-md-flex justify-content-between'>
             <div className='details'>
               <h6>Details:</h6>
@@ -98,6 +117,7 @@ const Document = ({ accessToken, addClass, acceptSOW, document, request }) => {
 
 Document.propTypes = {
   addClass: PropTypes.string,
+  backgroundColor: PropTypes.string,
   accessToken: PropTypes.string.isRequired,
   acceptSOW: PropTypes.func.isRequired,
   document: PropTypes.shape({
@@ -127,6 +147,7 @@ Document.propTypes = {
 
 Document.defaultProps = {
   addClass: '',
+  backgroundColor: 'secondary',
   document: {
     documentTypeColor: 'bg-dark',
     documentStatusColor: 'bg-secondary',

--- a/src/compounds/Document/Document.jsx
+++ b/src/compounds/Document/Document.jsx
@@ -45,7 +45,7 @@ const Document = ({ accessToken, addClass, acceptSOW, document, request }) => {
                 {/* TODO: @summer-cook SOW should have submit for approval. It should also ONLY show the submit for approval when the SOW has not yet been submitted. Need to figure out a way to tell if it has been submitted or not. . */}
                 <Dropdown.Item
                   href='#/action-1'
-                  onClick={() => {acceptSOW({data: request, sowID: identifier, accessToken: accessToken})}}
+                  onClick={() => {acceptSOW({request: request, sowID: identifier, accessToken: accessToken})}}
                 >
                   Submit for Approval
                 </Dropdown.Item>

--- a/src/compounds/Document/Document.jsx
+++ b/src/compounds/Document/Document.jsx
@@ -6,16 +6,15 @@ import Notice from '../../components/Notice/Notice'
 import { allowNull } from '../../resources/utilityFunctions'
 import './document.scss'
 
-const Document = ({ accessToken, addClass, acceptSOW, backgroundColor, document, request }) => {
+const Document = ({ addClass, acceptSOW, backgroundColor, document }) => {
   const { identifier, date, documentStatusColor, documentType,
     documentTypeColor, documentStatus, lineItems, requestIdentifier,
     shippingPrice, shipTo, shipFrom, sowID, subtotalPrice,
     taxAmount, terms, totalPrice } = document
   const [show, setShow] = useState(false)
-  const [sowAccepted, setSowAccepted] = useState(false)
+  const [showNotice, setShowNotice] = useState(false)
   const handleClose = () => setShow(false)
   const handleShow = () => setShow(true)
-
   return (
     <>
       <div className={`d-flex border rounded mb-2 bg-light document-wrapper ${addClass}`} onClick={handleShow} role='presentation'>
@@ -50,12 +49,8 @@ const Document = ({ accessToken, addClass, acceptSOW, backgroundColor, document,
                     <Dropdown.Item
                       href='#/action-1'
                       onClick={() => {
-                        acceptSOW({
-                          request,
-                          sowID,
-                          accessToken,
-                        })
-                        setSowAccepted(true)
+                        acceptSOW
+                        setShowNotice(true)
                       }}
                     >
                       Submit for Approval
@@ -66,19 +61,18 @@ const Document = ({ accessToken, addClass, acceptSOW, backgroundColor, document,
             )}
         </Offcanvas.Header>
         <Offcanvas.Body>
-          {sowAccepted
-            && (
-              <Row>
-                <Notice
-                  addClass='my-3'
-                  alert={{
-                    body: [`SOW ${identifier} has been accepted successfully. Now awaiting purchase order.`],
-                    variant: 'success',
-                    onClose: () => setSowAccepted(false),
-                  }}
-                />
-              </Row>
-            )}
+          {showNotice && (
+            <Row>
+              <Notice
+                addClass='my-3'
+                alert={{
+                  body: [alertBody],
+                  variant: 'success',
+                  onClose: () => setShowNotice(false),
+                }}
+              />
+            </Row>
+          )}
           <div className='d-block d-md-flex justify-content-between'>
             <div className='details'>
               <h6>Details:</h6>
@@ -100,8 +94,7 @@ const Document = ({ accessToken, addClass, acceptSOW, backgroundColor, document,
               <div className='address'>{shipFrom.text}</div>
             </div>
           </div>
-          {lineItems
-          && (
+          {lineItems && (
             <LineItemsTable
               lineItems={lineItems}
               subtotalPrice={subtotalPrice}
@@ -119,8 +112,8 @@ const Document = ({ accessToken, addClass, acceptSOW, backgroundColor, document,
 
 Document.propTypes = {
   addClass: PropTypes.string,
+  alertBody: PropTypes.string,
   backgroundColor: PropTypes.string,
-  accessToken: PropTypes.string.isRequired,
   acceptSOW: PropTypes.func.isRequired,
   document: PropTypes.shape({
     identifier: PropTypes.string.isRequired,
@@ -146,7 +139,6 @@ Document.propTypes = {
     terms: PropTypes.string.isRequired,
     totalPrice: PropTypes.string.isRequired,
   }),
-  request: PropTypes.string.isRequired,
 }
 
 Document.defaultProps = {

--- a/src/compounds/Document/Document.jsx
+++ b/src/compounds/Document/Document.jsx
@@ -7,7 +7,7 @@ import './document.scss'
 const Document = ({ accessToken, addClass, acceptSOW, document, request }) => {
   const { identifier, date, documentStatusColor, documentType,
     documentTypeColor, documentStatus, lineItems, requestIdentifier,
-    shippingPrice, shipTo, shipFrom, subtotalPrice,
+    shippingPrice, shipTo, shipFrom, sowID, subtotalPrice,
     taxAmount, terms, totalPrice } = document
   const [show, setShow] = useState(false)
   const handleClose = () => setShow(false)
@@ -45,7 +45,11 @@ const Document = ({ accessToken, addClass, acceptSOW, document, request }) => {
                 {/* TODO: @summer-cook SOW should have submit for approval. It should also ONLY show the submit for approval when the SOW has not yet been submitted. Need to figure out a way to tell if it has been submitted or not. . */}
                 <Dropdown.Item
                   href='#/action-1'
-                  onClick={() => {acceptSOW({request: request, sowID: identifier, accessToken: accessToken})}}
+                  onClick={() => {acceptSOW({
+                    request: request,
+                    sowID: sowID,
+                    accessToken: accessToken,
+                  })}}
                 >
                   Submit for Approval
                 </Dropdown.Item>

--- a/src/compounds/Document/Document.jsx
+++ b/src/compounds/Document/Document.jsx
@@ -16,6 +16,7 @@ const Document = ({ acceptSOW, addClass, backgroundColor, document }) => {
   const [showNotice, setShowNotice] = useState(false)
   const handleClose = () => setShow(false)
   const handleShow = () => setShow(true)
+
   return (
     <>
       <div className={`d-flex border rounded mb-2 bg-light document-wrapper ${addClass}`} onClick={handleShow} role='presentation'>

--- a/src/compounds/Document/Document.jsx
+++ b/src/compounds/Document/Document.jsx
@@ -48,7 +48,7 @@ const Document = ({ acceptSOW, addClass, backgroundColor, document }) => {
                   </Dropdown.Toggle>
                   <Dropdown.Menu>
                     <Dropdown.Item
-                      href='#/action-1'
+                      href='#/accept-sow'
                       onClick={() => {
                         acceptSOW
                         setShowNotice(true)


### PR DESCRIPTION
# expected behavior
- enables accepting a SOW from the button in the Document component
- makes the header of the document component have a background color so it is consistent to what we have in ViewFiles
- adds a Notice in the document component that shows when a sow is accepted. 
- Adds `addClass` and `onClose` optional props to the notice to make it more flexible/allows it to close from the Document component.

# Ref
ticket: https://github.com/scientist-softserv/webstore/issues/137
webstore pr: https://github.com/scientist-softserv/webstore/pull/229