### PR TITLE
165 link proptypes

### DIFF
--- a/src/components/FilesTable/FilesTable.jsx
+++ b/src/components/FilesTable/FilesTable.jsx
@@ -34,6 +34,7 @@ const FilesTable = ({ addClass, files }) => {
               <td className='text-center'>
                 <Link
                   icon='fa-download'
+                  label=''
                   href={href}
                   aria-label='download'
                 />

--- a/src/components/Link/Link.jsx
+++ b/src/components/Link/Link.jsx
@@ -3,32 +3,39 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import PropTypes from 'prop-types'
 import './link.css'
 
-const Link = ({ addClass, href, icon, label, style, ...props }) => (
-  <a
-    href={href}
-    className={`link ${addClass}`}
-    style={style}
-    {...props}
-  >
-    {icon && (
-      <FontAwesomeIcon icon={icon} className={`small ${label.length > 0 && 'me-2'}`} />
-    )}
-    {label}
-  </a>
-)
+const Link = ({ addClass, href, icon, label, style, ...props }) => {
+  return (
+    <a
+      href={href}
+      className={`link ${addClass}`}
+      style={style}
+      {...props}
+    >
+      {icon && (
+        <FontAwesomeIcon icon={icon} className={`small ${label.length && 'me-2'}`} />
+      )}
+      {label && label}
+    </a>
+  )
+}
 
+/**
+ * there isn't an easy way to require either the icon OR the label. there are additional packages we could install that have the
+ * capability, but that would bloat the package unnecessarily. instead, we're requiring that the label be passed. the overwhelming
+ * majority of instances where a link is used, will want a label anyway. however, in the event a label isn't desired, passing the
+ * value as an empty string will satisfy prop types, while still only showing an icon.
+*/
 Link.propTypes = {
   addClass: PropTypes.string,
   href: PropTypes.string.isRequired,
   icon: PropTypes.string,
-  label: PropTypes.string,
+  label: PropTypes.string.isRequired,
   style: PropTypes.shape({}),
 }
 
 Link.defaultProps = {
   addClass: '',
   icon: '',
-  label: '',
   style: {},
 }
 

--- a/src/components/Link/Link.stories.jsx
+++ b/src/components/Link/Link.stories.jsx
@@ -21,10 +21,21 @@ Default.args = {
 export const Alternate = Template.bind({})
 Alternate.args = {
   href: '',
+  icon: 'fa-envelope',
   label: 'No underline!',
   style: {
     textDecoration: 'none',
     color: '#AB1289',
   },
-  icon: 'fa-envelope',
+}
+
+export const NoLabel = Template.bind({})
+NoLabel.args = {
+  href: '',
+  icon: 'fa-download',
+  label: '',
+  style: {
+    textDecoration: 'none',
+    color: '#AS8908',
+  },
 }

--- a/src/components/Link/Link.stories.jsx
+++ b/src/components/Link/Link.stories.jsx
@@ -13,14 +13,14 @@ const Template = (args) => <Link {...args} />
 
 export const Default = Template.bind({})
 Default.args = {
-  href: '',
+  href: '/',
   label: 'I am a link',
   style: {},
 }
 
 export const Alternate = Template.bind({})
 Alternate.args = {
-  href: '',
+  href: '/',
   icon: 'fa-envelope',
   label: 'No underline!',
   style: {
@@ -31,11 +31,8 @@ Alternate.args = {
 
 export const NoLabel = Template.bind({})
 NoLabel.args = {
-  href: '',
+  href: '/',
   icon: 'fa-download',
   label: '',
-  style: {
-    textDecoration: 'none',
-    color: '#AS8908',
-  },
+  style: {},
 }


### PR DESCRIPTION
# story

# expected behavior
- make the label required on a link. however, it can be an empty string if the desire is to only show an icon

# demo
<details>
<summary>link with just text</summary>

![image](https://user-images.githubusercontent.com/29032869/221234907-c3a02d89-fc61-4b9c-af7e-fbb2174e99cb.png)
</details>

<details>
<summary>link with text and an icon</summary>

![image](https://user-images.githubusercontent.com/29032869/221234973-d7633cc9-303d-4dba-aa07-c7a6ab65718f.png)
</details>

<details>
<summary>link with just an icon</summary>

![image](https://user-images.githubusercontent.com/29032869/221235069-3cf7bea0-9c4d-49e6-ae87-3721409744ca.png)
</details>