### PR TITLE
138 display pos

### DIFF
--- a/src/components/StatusBar/StatusBar.jsx
+++ b/src/components/StatusBar/StatusBar.jsx
@@ -16,7 +16,7 @@ const StatusBar = ({ backgroundColor, statusArray, apiRequestStatus, addClass })
 
   return (
     <div className={`container ${addClass}`}>
-      <div className='row border'>
+      <div className='row border' data-cy='status-bar'>
         {statusArray.map((statusObject, index) => {
           const { statusLabel, statusIcon } = statusObject
           const border = index !== statusArray.length - 1 ? 'border-end' : ''

--- a/src/compounds/Document/Document.jsx
+++ b/src/compounds/Document/Document.jsx
@@ -76,13 +76,15 @@ const Document = ({ document, addClass }) => {
               <div className='address'>{shipFrom.text}</div>
             </div>
           </div>
-          <LineItemsTable
-            lineItems={lineItems}
-            subtotalPrice={subtotalPrice}
-            taxAmount={taxAmount}
-            shippingPrice={shippingPrice}
-            totalPrice={totalPrice}
-          />
+          {lineItems && (
+            <LineItemsTable
+              lineItems={lineItems}
+              subtotalPrice={subtotalPrice}
+              taxAmount={taxAmount}
+              shippingPrice={shippingPrice}
+              totalPrice={totalPrice}
+            />
+          )}
           {turnaroundTime && <h5><b>Turnaround Time:</b> {turnaroundTime}</h5>}
         </Offcanvas.Body>
       </Offcanvas>

--- a/src/compounds/Document/Document.jsx
+++ b/src/compounds/Document/Document.jsx
@@ -21,7 +21,7 @@ const Document = ({ document, addClass }) => {
             {documentType}
           </div>
           <div className='border-end p-2'>
-            <b>{identifier}:</b> {subtotalPrice}
+            <b>{(documentType === 'SOW') ? identifier : poNumber}:</b> {subtotalPrice}
           </div>
           <small className='text-muted fw-light p-2'>
             {date}

--- a/src/compounds/Document/Document.jsx
+++ b/src/compounds/Document/Document.jsx
@@ -5,10 +5,10 @@ import LineItemsTable from '../../components/LineItemsTable/LineItemsTable'
 import './document.scss'
 
 const Document = ({ document, addClass }) => {
-  const { identifier, date, documentStatusColor, documentType,
-    documentTypeColor, documentStatus, lineItems, requestIdentifier,
+  const { adPO, date, documentStatusColor, documentType,
+    documentTypeColor, documentStatus, identifier, lineItems, poNumber, relatedSOWIdentifier, requestIdentifier,
     shippingPrice, shipTo, shipFrom, subtotalPrice,
-    taxAmount, terms, totalPrice } = document
+    taxAmount, terms, totalPrice, turnaroundTime } = document
   const [show, setShow] = useState(false)
   const handleClose = () => setShow(false)
   const handleShow = () => setShow(true)
@@ -52,8 +52,13 @@ const Document = ({ document, addClass }) => {
         <Offcanvas.Body>
           <div className='d-block d-md-flex justify-content-between'>
             <div className='details'>
-              <h6>Details:</h6>
-              <b>Proposal:</b> {identifier}<br />
+              <h5>Details:</h5>
+              {poNumber && <><b>PO:</b> {poNumber}<br /></>}
+              {adPO && <><b>AD PO:</b> {identifier}<br /></>}
+              {documentType === 'SOW' ? 
+                <><b>Proposal:</b> {identifier}</> :
+                <><b>Related SOW:</b> {relatedSOWIdentifier}</>
+              }<br />
               <b>Amount:</b> {subtotalPrice}<br />
               <b>Request:</b> {requestIdentifier} <br />
               <b>Date:</b> {date}<br />
@@ -81,6 +86,7 @@ const Document = ({ document, addClass }) => {
               totalPrice={totalPrice}
             />
           )}
+          {turnaroundTime && <><h5><b>Turnaround Time:</b> {turnaroundTime}</h5></>}
         </Offcanvas.Body>
       </Offcanvas>
     </>

--- a/src/compounds/Document/Document.jsx
+++ b/src/compounds/Document/Document.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import { Dropdown, Offcanvas } from 'react-bootstrap'
 import LineItemsTable from '../../components/LineItemsTable/LineItemsTable'
 import './document.scss'
+import { allowNull } from '../../resources/utilityFunctions'
 
 const Document = ({ document, addClass }) => {
   const { adPO, date, documentStatusColor, documentType,
@@ -28,7 +29,7 @@ const Document = ({ document, addClass }) => {
           </small>
         </div>
         <div className='ms-auto p-2'>
-          <div className='badge p-2' style={{backgroundColor: documentStatusColor}}>
+          <div className='badge p-2' style={{ backgroundColor: documentStatusColor }}>
             {documentStatus}
           </div>
         </div>
@@ -55,10 +56,9 @@ const Document = ({ document, addClass }) => {
               <h5>Details:</h5>
               {poNumber && <><b>PO:</b> {poNumber}<br /></>}
               {adPO && <><b>AD PO:</b> {identifier}<br /></>}
-              {documentType === 'SOW' ? 
-                <><b>Proposal:</b> {identifier}</> :
-                <><b>Related SOW:</b> {relatedSOWIdentifier}</>
-              }<br />
+              {documentType === 'SOW'
+                ? <><b>Proposal:</b> {identifier}</>
+                : <><b>Related SOW:</b> {relatedSOWIdentifier}</>}<br />
               <b>Amount:</b> {subtotalPrice}<br />
               <b>Request:</b> {requestIdentifier} <br />
               <b>Date:</b> {date}<br />
@@ -86,7 +86,7 @@ const Document = ({ document, addClass }) => {
               totalPrice={totalPrice}
             />
           )}
-          {turnaroundTime && <><h5><b>Turnaround Time:</b> {turnaroundTime}</h5></>}
+          {turnaroundTime && <h5><b>Turnaround Time:</b> {turnaroundTime}</h5>}
         </Offcanvas.Body>
       </Offcanvas>
     </>
@@ -97,6 +97,7 @@ const Document = ({ document, addClass }) => {
 Document.propTypes = {
   addClass: PropTypes.string,
   document: PropTypes.shape({
+    adPO: allowNull(PropTypes.string.isRequired),
     identifier: PropTypes.string.isRequired,
     date: PropTypes.string.isRequired,
     documentStatus: PropTypes.string.isRequired,
@@ -104,6 +105,8 @@ Document.propTypes = {
     documentType: PropTypes.string.isRequired,
     documentTypeColor: PropTypes.string,
     lineItems: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+    poNumber: allowNull(PropTypes.string.isRequired),
+    relatedSOWIdentifier: allowNull(PropTypes.string.isRequired),
     requestIdentifier: PropTypes.string.isRequired,
     shippingPrice: PropTypes.string.isRequired,
     shipTo: PropTypes.shape({
@@ -118,6 +121,7 @@ Document.propTypes = {
     taxAmount: PropTypes.string.isRequired,
     terms: PropTypes.string.isRequired,
     totalPrice: PropTypes.string.isRequired,
+    turnaroundTime: allowNull(PropTypes.string.isRequired),
   }),
 }
 

--- a/src/compounds/Document/Document.jsx
+++ b/src/compounds/Document/Document.jsx
@@ -3,13 +3,13 @@ import PropTypes from 'prop-types'
 import { Dropdown, Offcanvas } from 'react-bootstrap'
 import LineItemsTable from '../../components/LineItemsTable/LineItemsTable'
 import './document.scss'
-import { allowNull } from '../../resources/utilityFunctions'
 
 const Document = ({ document, addClass }) => {
-  const { adPO, date, documentStatusColor, documentType,
-    documentTypeColor, documentStatus, identifier, lineItems, poNumber, relatedSOWIdentifier, requestIdentifier,
-    shippingPrice, shipTo, shipFrom, subtotalPrice,
-    taxAmount, terms, totalPrice, turnaroundTime } = document
+  const {
+    adPO, date, documentStatusColor, documentType, documentTypeColor, documentStatus, identifier, lineItems, poNumber,
+    relatedSOWIdentifier, requestIdentifier, shippingPrice, shipTo, shipFrom, subtotalPrice, taxAmount, terms, totalPrice,
+    turnaroundTime,
+  } = document
   const [show, setShow] = useState(false)
   const handleClose = () => setShow(false)
   const handleShow = () => setShow(true)
@@ -76,16 +76,13 @@ const Document = ({ document, addClass }) => {
               <div className='address'>{shipFrom.text}</div>
             </div>
           </div>
-          {lineItems
-          && (
-            <LineItemsTable
-              lineItems={lineItems}
-              subtotalPrice={subtotalPrice}
-              taxAmount={taxAmount}
-              shippingPrice={shippingPrice}
-              totalPrice={totalPrice}
-            />
-          )}
+          <LineItemsTable
+            lineItems={lineItems}
+            subtotalPrice={subtotalPrice}
+            taxAmount={taxAmount}
+            shippingPrice={shippingPrice}
+            totalPrice={totalPrice}
+          />
           {turnaroundTime && <h5><b>Turnaround Time:</b> {turnaroundTime}</h5>}
         </Offcanvas.Body>
       </Offcanvas>
@@ -97,7 +94,7 @@ const Document = ({ document, addClass }) => {
 Document.propTypes = {
   addClass: PropTypes.string,
   document: PropTypes.shape({
-    adPO: allowNull(PropTypes.string.isRequired),
+    adPO: PropTypes.string,
     identifier: PropTypes.string.isRequired,
     date: PropTypes.string.isRequired,
     documentStatus: PropTypes.string.isRequired,
@@ -105,8 +102,8 @@ Document.propTypes = {
     documentType: PropTypes.string.isRequired,
     documentTypeColor: PropTypes.string,
     lineItems: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
-    poNumber: allowNull(PropTypes.string.isRequired),
-    relatedSOWIdentifier: allowNull(PropTypes.string.isRequired),
+    poNumber: PropTypes.string,
+    relatedSOWIdentifier: PropTypes.string,
     requestIdentifier: PropTypes.string.isRequired,
     shippingPrice: PropTypes.string.isRequired,
     shipTo: PropTypes.shape({
@@ -121,7 +118,7 @@ Document.propTypes = {
     taxAmount: PropTypes.string.isRequired,
     terms: PropTypes.string.isRequired,
     totalPrice: PropTypes.string.isRequired,
-    turnaroundTime: allowNull(PropTypes.string.isRequired),
+    turnaroundTime: PropTypes.string,
   }),
 }
 


### PR DESCRIPTION
# Summary
adds the correct info for POs onto the document component
also adds a data-cy attribute on the status bar for a separate test

# Related
webstore PR: https://github.com/scientist-softserv/webstore/pull/254
webstore ticket: https://github.com/scientist-softserv/webstore/issues/138

# screenshots
<img width="1229" alt="image" src="https://user-images.githubusercontent.com/73361970/223216709-8015fb4a-d87b-4e02-bb5a-502c2ef3d1ed.png">
<img width="1085" alt="image" src="https://user-images.githubusercontent.com/73361970/223216751-d90abe16-9231-46a5-a00f-578a0933f58e.png">

