### PR TITLE
next link story arg update

### DIFF
--- a/src/components/NextLink/NextLink.stories.jsx
+++ b/src/components/NextLink/NextLink.stories.jsx
@@ -12,5 +12,8 @@ export const Default = Template.bind({})
 Default.args = {
   text: 'Text Here',
   addClass: '',
-  path: '/',
+  path: {
+    pathname: '/test',
+    query: {},
+  },
 }


### PR DESCRIPTION
# story
update the nextlink component story "path" arg to match the prop type.
``` js
path: PropTypes.exact({
  pathname: PropTypes.string.isRequired,
  query: PropTypes.shape({}),
}).isRequired
```

# expected behavior
- the "path" arg is an object with "pathname" and "query" keys instead of a string