### PR TITLE
Get markdown working on browse pages, homepage should still use snippet

### DIFF
--- a/src/compounds/Item/CardBody.jsx
+++ b/src/compounds/Item/CardBody.jsx
@@ -78,6 +78,14 @@ CardBody.propTypes = {
     name: PropTypes.string.isRequired,
     slug: PropTypes.string,
   }),
+  markdownDescriptionTruncated: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.elementType,
+  ]),
+  markdownDescriptionExtended: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.elementType,
+  ]),
   orientation: PropTypes.oneOf(['horizontal', 'vertical']),
   titleLink: PropTypes.string,
   withButtonLink: PropTypes.bool,
@@ -90,6 +98,8 @@ CardBody.defaultProps = {
   item: {
     description: '',
   },
+  markdownDescriptionTruncated: '',
+  markdownDescriptionExtended: '',
   orientation: 'vertical',
   titleLink: '',
   withButtonLink: false,

--- a/src/compounds/Item/CardBody.jsx
+++ b/src/compounds/Item/CardBody.jsx
@@ -4,19 +4,10 @@ import { Button, Card, Collapse } from 'react-bootstrap'
 import NextLink from '../../components/NextLink/NextLink'
 import LinkedButton from '../LinkedButton/LinkedButton'
 
-const CardBody = ({ buttonLink, buttonProps, item,
-  orientation, titleLink, withButtonLink, withTitleLink }) => {
-  const { id, description = '', name } = item
+const CardBody = ({ buttonLink, buttonProps, item, markdownDescriptionTruncated, markdownDescriptionExtended, orientation, titleLink, withButtonLink, withTitleLink }) => {
+  const { id, description, name, snippet } = item
   const [open, setOpen] = useState(false)
 
-  const truncateDescription = (desc, maxLength, isOpen) => {
-    if (desc.length <= maxLength || isOpen) return { truncated: desc, cutOffIndex: desc.length };
-    const lastSpaceIndex = desc.substring(0, maxLength).lastIndexOf(' ');
-    const ellipsis = isOpen ? '' : '...';
-    return { truncated: desc.slice(0, lastSpaceIndex) + ellipsis, cutOffIndex: lastSpaceIndex };
-  }
-
-  const { truncated, cutOffIndex } = truncateDescription(description, 300, open)
   return (
     <Card.Body className={withButtonLink && 'd-flex flex-column'}>
       <div className={orientation === 'horizontal' ? 'd-block d-md-flex align-items-center justify-content-between' : ''}>
@@ -33,21 +24,25 @@ const CardBody = ({ buttonLink, buttonProps, item,
               name
             )}
           </Card.Title>
-          {description && (
-            <>
-              <div className='fw-light mh-300 overflow-auto mt-3'>
-                {truncated}
-                <Collapse in={open}>
-                  <div className='fw-light'>{description.slice(cutOffIndex).trimStart()}</div>
-                </Collapse>
-              </div>
-              {description.length > 300 && (
-                <Button variant="link" onClick={() => setOpen(!open)} className="p-0 mt-3">
-                  {open ? ' Show less' : ' Read more'}
-                </Button>
+            {orientation === 'horizontal' ? (
+              <>
+                <div className='fw-light mh-300 overflow-auto mt-3'>
+                {markdownDescriptionTruncated}
+                  <Collapse in={open}>
+                    <div className='fw-light'>{markdownDescriptionExtended}</div>
+                  </Collapse>
+                </div>
+                {description?.length > 300 && (
+                  <Button variant="link" onClick={() => setOpen(!open)} className="p-0 mt-3">
+                    {open ? ' Show less' : ' Read more'}
+                  </Button>
+                )}
+              </>
+              ) : (
+                <div className='fw-light'>
+                  {snippet}
+                </div>
               )}
-            </>
-          )}
         </div>
         {(withButtonLink) && (
           <div className={orientation === 'horizontal' ? 'mt-3 mt-md-0' : 'mt-3'}>

--- a/src/compounds/Item/Item.jsx
+++ b/src/compounds/Item/Item.jsx
@@ -8,7 +8,7 @@ import ItemLoading from './ItemLoading'
 import NextLink from '../../components/NextLink/NextLink'
 import './item.scss'
 
-const Item = ({ buttonLink, buttonProps, href, isLoading, item, orientation, titleLink, withButtonLink,
+const Item = ({ buttonLink, buttonProps, markdownDescriptionTruncated, markdownDescriptionExtended, href, isLoading, item, orientation, titleLink, withButtonLink,
   withTitleLink, width }) => {
   if (isLoading) {
     return (
@@ -45,6 +45,8 @@ const Item = ({ buttonLink, buttonProps, href, isLoading, item, orientation, tit
               buttonLink={link}
               buttonProps={buttonProps}
               item={item}
+              markdownDescriptionTruncated={markdownDescriptionTruncated}
+              markdownDescriptionExtended={markdownDescriptionExtended}
               orientation={orientation}
               titleLink={link}
               withButtonLink={withButtonLink}
@@ -65,6 +67,8 @@ const Item = ({ buttonLink, buttonProps, href, isLoading, item, orientation, tit
                 buttonLink={link}
                 buttonProps={buttonProps}
                 item={item}
+                markdownDescriptionTruncated={markdownDescriptionTruncated}
+                markdownDescriptionExtended={markdownDescriptionExtended}
                 orientation={orientation}
                 titleLink={link}
                 withButtonLink={withButtonLink}

--- a/src/compounds/Item/Item.stories.jsx
+++ b/src/compounds/Item/Item.stories.jsx
@@ -31,6 +31,8 @@ Default.args = {
   style: {},
   withButtonLink: false,
   withTitleLink: false,
+  markdownDescriptionTruncated: 'Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old.',
+  markdownDescriptionExtended: ' Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, "Lorem ipsum dolor sit amet..", comes from a line in section 1.10.32.'
 }
 
 export const isLoading = Template.bind({})


### PR DESCRIPTION
# Related
- Webstore PR: https://github.com/scientist-softserv/webstore/pull/367
- Ticket: https://github.com/scientist-softserv/webstore-component-library/issues/205


# Expected Behavior Before Changes
- As a user, I would not see markdown in descriptions on the browse page that contain markdown

# Expected Behavior After Changes
- As a user, i will see markdown in descriptions on the browse page that contain markdown
-  As a user, I will see snippets on the featured service page, and descriptions on the browse/search page. 

# Screenshots / Video
<details>
<summary>Browse page will use description with markdown</summary>
Video: https://share.zight.com/o0uOqZx2

<img width="1302" alt="image" src="https://github.com/scientist-softserv/webstore/assets/73361970/4226cad1-5d77-4d0d-a844-700cfd9b44b9">

</details>

<details>
<summary>Featured services will still use snippet</summary>
<img width="1356" alt="image" src="https://github.com/scientist-softserv/webstore/assets/73361970/5e953e7f-12aa-4af3-a419-0415b7f9776c">

</details>