### PR TITLE
209-nav-logo-size

### DIFF
--- a/src/compounds/Header/Header.jsx
+++ b/src/compounds/Header/Header.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Container, Nav, Navbar } from 'react-bootstrap'
 import Logo from '../Logo/Logo'
+import './styles.scss'
 
 const Header = ({ auth, linkColor, logo, navLinks, userSession }) => {
   const { src, alt } = logo
@@ -9,8 +10,8 @@ const Header = ({ auth, linkColor, logo, navLinks, userSession }) => {
   return (
     <Navbar bg='primary' expand='lg'>
       <Container>
-        <Navbar.Brand className='w-50'>
-          <Logo src={src} alt={alt} height={45} />
+        <Navbar.Brand className='w-75 custom-navbar-brand'>
+          <Logo src={src} alt={alt} height='auto' addClass='mw-100 mh-100' />
         </Navbar.Brand>
         <Navbar.Toggle aria-controls='basic-navbar-nav' />
         <Navbar.Collapse id='basic-navbar-nav'>

--- a/src/compounds/Header/styles.scss
+++ b/src/compounds/Header/styles.scss
@@ -1,0 +1,3 @@
+.custom-navbar-brand {
+  height: 45px;
+}


### PR DESCRIPTION
# story
[contain the logo in the navbar](https://github.com/scientist-softserv/webstore-component-library/commit/a3b01cd364c5e6d17a1ddbfc69816f63c07eece7)

previously, wide logo's would overflow the width of the Navbar.Brand. this commit adds height to the brand element, instead of the logo image, containing the logo height and width within the Navbar.Brand.

there isn't a bootstrap element that sets height to a specific value. the choice was to use inline styles or create a new class. I opted to create a new class. it's specific to the Header component so it's not in globals.scss. the name "custom-navbar-brand" makes it easier to denote that it's our class and not bootstrap's when inspecting from the browser.

# demo
<details>
<summary>example with tall logo</summary>

<img width="780" alt="image" src="https://github.com/scientist-softserv/webstore-component-library/assets/29032869/6b63601c-69ab-4701-95cd-4e2666a5cffb">
<img width="495" alt="image" src="https://github.com/scientist-softserv/webstore-component-library/assets/29032869/e01a042d-93e5-4938-a532-35c9e7db2d78">
</details>

<details>
<summary>example with wide logo</summary>

<img width="781" alt="image" src="https://github.com/scientist-softserv/webstore-component-library/assets/29032869/add08d1c-88ed-4214-8668-938f16ed5f95">
<img width="495" alt="image" src="https://github.com/scientist-softserv/webstore-component-library/assets/29032869/e2190ecf-066a-466c-8e21-e9663e1263fe">

</details>