### PR TITLE
211-mobile-view-cutoff

### DIFF
--- a/src/compounds/ItemGroup/ItemGroup.jsx
+++ b/src/compounds/ItemGroup/ItemGroup.jsx
@@ -9,7 +9,7 @@ import './item-group.scss'
 const ItemGroup = ({ buttonProps, items, isLoading, orientation, withButtonLink, withTitleLink }) => (
   <>
     <Title addClass='mb-2' size='large' title='Featured Services' />
-    <Row xs={1} sm={2} className={`g-5 mb-5 ${orientation === 'vertical' && 'row-cols-md-3'}`} data-cy='item-group'>
+    <Row xs={1} sm={2} className={`gy-5 mb-5 ${orientation === 'vertical' && 'row-cols-md-3'}`} data-cy='item-group'>
       {isLoading
         ? (
           <>


### PR DESCRIPTION
# story
[remove unintended white space on mobile](https://github.com/scientist-softserv/webstore-component-library/commit/5e0d3ddec5e1fccbf2077bf54710c07c6e8dfec1)

when viewing the webstore on mobile, or inspecting from the browser using a mobile device, there was extra white space alone the right side of the page. turns out that the ItemGroup component was causing it.

we're using a bootstrap grid class that was adding x/y gutters in between each item. this commit removes the horizontal (x) gutter, opting only for the vertical (y) gutter. the page still looks good on desktop too.

- ref: https://getbootstrap.com/docs/5.0/layout/gutters/

# demo
| | before | after |
| --- | --- | --- |
| mobile | <img width="437" alt="image" src="https://github.com/scientist-softserv/webstore-component-library/assets/29032869/994e8a7d-c609-4928-84ca-30af3d665636"> | <img width="437" alt="image" src="https://github.com/scientist-softserv/webstore-component-library/assets/29032869/fc800d11-e9f8-4e0a-9431-f9d480e01914">|
|desktop | <img width="722" alt="image" src="https://github.com/scientist-softserv/webstore-component-library/assets/29032869/0d5f26de-ff51-4bd5-894c-4dfc5715c36a"> | <img width="716" alt="image" src="https://github.com/scientist-softserv/webstore-component-library/assets/29032869/b29ebf32-6eb8-4def-aa56-1665c230b77b">|